### PR TITLE
Centralize notifications

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,3 @@
 <app-navbar></app-navbar>
 <router-outlet></router-outlet>
+<app-notification></app-notification>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,11 +1,12 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { NavbarComponent } from './shared/components/navbar/navbar.component';
+import { NotificationComponent } from './shared/components/notification/notification.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, NavbarComponent],
+  imports: [RouterOutlet, NavbarComponent, NotificationComponent],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -196,21 +196,3 @@
   </div>
 </section>
 
-<!-- =======================
-🔔 NOTIFICATIONS
-======================= -->
-<div class="notifications">
-  <div *ngFor="let notification of notifications" 
-       class="notification"
-       [class.notification--success]="notification.type === 'success'"
-       [class.notification--warning]="notification.type === 'warning'"
-       [class.notification--error]="notification.type === 'error'">
-    <div class="notification__header">
-      <span class="notification__title">{{notification.title}}</span>
-      <button class="notification__close" (click)="removeNotification(notification)">
-        <i class="fas fa-times"></i>
-      </button>
-    </div>
-    <p class="notification__message">{{notification.message}}</p>
-  </div>
-</div>

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -753,65 +753,7 @@ $error-color: #dc3545;
   }
 }
 
-// Notifications
-.notifications {
-  position: fixed;
-  top: 20px;
-  right: 20px;
-  z-index: 1000;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
 
-.notification {
-  background: white;
-  padding: 1rem;
-  border-radius: 8px;
-  min-width: 300px;
-  @include card-shadow;
-
-  &__header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 0.5rem;
-  }
-
-  &__title {
-    font-weight: 500;
-    color: $text-color;
-  }
-
-  &__close {
-    background: none;
-    border: none;
-    color: color.mix($text-color, white, 80%);
-    cursor: pointer;
-    padding: 0.25rem;
-    
-    &:hover {
-      color: $text-color;
-    }
-  }
-
-  &__message {
-    color: color.mix($text-color, white, 80%);
-    font-size: 0.9rem;
-  }
-
-  &--success {
-    border-left: 4px solid $success-color;
-  }
-
-  &--warning {
-    border-left: 4px solid $warning-color;
-  }
-
-  &--error {
-    border-left: 4px solid $error-color;
-  }
-}
 
 // Responsive Design
 @media (max-width: 1200px) {
@@ -923,7 +865,4 @@ $error-color: #dc3545;
     grid-template-columns: 1fr;
   }
 
-  .notification {
-    min-width: calc(100vw - 40px);
-  }
 }

--- a/src/app/shared/components/notification/notification.component.ts
+++ b/src/app/shared/components/notification/notification.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { NotificationService } from '../../services/notification.service';
 import { Subscription } from 'rxjs';
 
@@ -13,6 +14,8 @@ export interface Notification {
 
 @Component({
   selector: 'app-notification',
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './notification.component.html',
   styleUrls: ['./notification.component.scss']
 })


### PR DESCRIPTION
## Summary
- make `NotificationComponent` standalone so it can be used in any view
- show global notifications from `AppComponent`
- use `NotificationService` in `HomeComponent`
- drop old notification markup and styles

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ca00adfcc832eb820d74b2538bffc