### PR TITLE
Add services pages

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -30,6 +30,10 @@ export const routes: Routes = [
     children: HISTORY_ROUTES
   },
   {
+    path: 'services',
+    loadChildren: () => import('./pages/services/services.routes').then(m => m.SERVICES_ROUTES)
+  },
+  {
     path: 'help',
     loadChildren: () => import('./pages/help/help.routes').then(m => m.HELP_ROUTES)
   },

--- a/src/app/pages/services/generate-barcode.component.html
+++ b/src/app/pages/services/generate-barcode.component.html
@@ -1,0 +1,4 @@
+<section class="generate-barcode">
+  <h2>Generate Barcode</h2>
+  <p>Create barcodes to easily identify your shipments.</p>
+</section>

--- a/src/app/pages/services/generate-barcode.component.scss
+++ b/src/app/pages/services/generate-barcode.component.scss
@@ -1,0 +1,3 @@
+.generate-barcode {
+  padding: 1rem;
+}

--- a/src/app/pages/services/generate-barcode.component.ts
+++ b/src/app/pages/services/generate-barcode.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-generate-barcode',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './generate-barcode.component.html',
+  styleUrls: ['./generate-barcode.component.scss']
+})
+export class GenerateBarcodeComponent {}

--- a/src/app/pages/services/notifications.component.html
+++ b/src/app/pages/services/notifications.component.html
@@ -1,0 +1,4 @@
+<section class="notifications">
+  <h2>Notifications</h2>
+  <p>Stay informed of every update with instant alerts.</p>
+</section>

--- a/src/app/pages/services/notifications.component.scss
+++ b/src/app/pages/services/notifications.component.scss
@@ -1,0 +1,3 @@
+.notifications {
+  padding: 1rem;
+}

--- a/src/app/pages/services/notifications.component.ts
+++ b/src/app/pages/services/notifications.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-notifications',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './notifications.component.html',
+  styleUrls: ['./notifications.component.scss']
+})
+export class NotificationsComponent {}

--- a/src/app/pages/services/services.routes.ts
+++ b/src/app/pages/services/services.routes.ts
@@ -1,0 +1,19 @@
+import { Routes } from '@angular/router';
+import { TrackByMailComponent } from './track-by-mail.component';
+import { GenerateBarcodeComponent } from './generate-barcode.component';
+import { NotificationsComponent } from './notifications.component';
+
+export const SERVICES_ROUTES: Routes = [
+  {
+    path: 'track-by-mail',
+    component: TrackByMailComponent
+  },
+  {
+    path: 'generate-barcode',
+    component: GenerateBarcodeComponent
+  },
+  {
+    path: 'notifications',
+    component: NotificationsComponent
+  }
+];

--- a/src/app/pages/services/track-by-mail.component.html
+++ b/src/app/pages/services/track-by-mail.component.html
@@ -1,0 +1,4 @@
+<section class="track-by-mail">
+  <h2>Track by Mail</h2>
+  <p>Receive shipment updates directly in your inbox.</p>
+</section>

--- a/src/app/pages/services/track-by-mail.component.scss
+++ b/src/app/pages/services/track-by-mail.component.scss
@@ -1,0 +1,3 @@
+.track-by-mail {
+  padding: 1rem;
+}

--- a/src/app/pages/services/track-by-mail.component.ts
+++ b/src/app/pages/services/track-by-mail.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-track-by-mail',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './track-by-mail.component.html',
+  styleUrls: ['./track-by-mail.component.scss']
+})
+export class TrackByMailComponent {}


### PR DESCRIPTION
## Summary
- add track-by-mail, generate-barcode and notifications components
- configure SERVICES_ROUTES
- register services routes in app.routes

## Testing
- `npm test` *(fails: No Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_684ce630c9a4832eae36f1a8df625f22