### PR TITLE
Add router links for contact/support

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,6 +2,8 @@ import { Routes } from '@angular/router';
 import { ADVANCED_SHIPMENT_TRACKING_ROUTES } from './pages/advanced-shipment-tracking/advanced-shipment-tracking.routes';
 import { HISTORY_ROUTES } from './pages/history/history.routes';
 import { HOME_ROUTES } from './pages/home/home.routes';
+import { CONTACT_ROUTES } from './pages/contact/contact.routes';
+import { SUPPORT_ROUTES } from './pages/support/support.routes';
 
 export const routes: Routes = [
   {
@@ -32,6 +34,14 @@ export const routes: Routes = [
   {
     path: 'help',
     loadChildren: () => import('./pages/help/help.routes').then(m => m.HELP_ROUTES)
+  },
+  {
+    path: 'contact',
+    children: CONTACT_ROUTES
+  },
+  {
+    path: 'support',
+    children: SUPPORT_ROUTES
   },
   {
     path: 'profile',

--- a/src/app/pages/contact/contact.component.html
+++ b/src/app/pages/contact/contact.component.html
@@ -1,0 +1,4 @@
+<section class="contact-page">
+  <h1>Contact Us</h1>
+  <p>This is a placeholder contact page.</p>
+</section>

--- a/src/app/pages/contact/contact.component.scss
+++ b/src/app/pages/contact/contact.component.scss
@@ -1,0 +1,3 @@
+.contact-page {
+  padding: 2rem;
+}

--- a/src/app/pages/contact/contact.component.ts
+++ b/src/app/pages/contact/contact.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-contact',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './contact.component.html',
+  styleUrls: ['./contact.component.scss']
+})
+export class ContactComponent {}

--- a/src/app/pages/contact/contact.routes.ts
+++ b/src/app/pages/contact/contact.routes.ts
@@ -1,0 +1,10 @@
+import { Routes } from '@angular/router';
+import { ContactComponent } from './contact.component';
+
+export const CONTACT_ROUTES: Routes = [
+  {
+    path: '',
+    component: ContactComponent,
+    title: 'Contact'
+  }
+];

--- a/src/app/pages/home/components/cta/cta-section.component.html
+++ b/src/app/pages/home/components/cta/cta-section.component.html
@@ -3,11 +3,11 @@
     <h2>Need Help?</h2>
     <p>Our team is available 24/7 to assist you</p>
     <div class="cta__buttons">
-      <a href="/contact" class="btn btn--primary">
+      <a routerLink="/contact" class="btn btn--primary">
         <i class="fas fa-headset"></i>
         Contact Us
       </a>
-      <a href="/support" class="btn btn--secondary">
+      <a routerLink="/support" class="btn btn--secondary">
         <i class="fas fa-question-circle"></i>
         Help Center
       </a>

--- a/src/app/pages/support/support.component.html
+++ b/src/app/pages/support/support.component.html
@@ -1,0 +1,4 @@
+<section class="support-page">
+  <h1>Support Center</h1>
+  <p>This is a placeholder support page.</p>
+</section>

--- a/src/app/pages/support/support.component.scss
+++ b/src/app/pages/support/support.component.scss
@@ -1,0 +1,3 @@
+.support-page {
+  padding: 2rem;
+}

--- a/src/app/pages/support/support.component.ts
+++ b/src/app/pages/support/support.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-support',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './support.component.html',
+  styleUrls: ['./support.component.scss']
+})
+export class SupportComponent {}

--- a/src/app/pages/support/support.routes.ts
+++ b/src/app/pages/support/support.routes.ts
@@ -1,0 +1,10 @@
+import { Routes } from '@angular/router';
+import { SupportComponent } from './support.component';
+
+export const SUPPORT_ROUTES: Routes = [
+  {
+    path: '',
+    component: SupportComponent,
+    title: 'Support'
+  }
+];


### PR DESCRIPTION
## Summary
- add router links in CTA section
- create placeholder pages for contact and support
- wire new pages in application routes

## Testing
- `npx ng test --watch=false` *(fails: could not determine executable)*

------
https://chatgpt.com/codex/tasks/task_e_684ce63a5250832ea160527a8cfe1754