### PR TITLE
Add navigation events for Pro Scan and Proof actions

### DIFF
--- a/src/app/pages/home/components/hero/hero-section.component.html
+++ b/src/app/pages/home/components/hero/hero-section.component.html
@@ -38,15 +38,15 @@
           <p>Drag and drop or click to upload</p>
           <input type="file" accept="image/*" (change)="onBarcodeFileSelected($event)" #fileInput hidden>
         </div>
-        <button class="btn btn--primary mt-3">Pro Scan (Webcam - Coming Soon)</button>
+        <button class="btn btn--primary mt-3" (click)="onProScanClick()">Pro Scan</button>
       </div>
 
       <div *ngIf="selectedHeroFeature === 'obtain_proof'" class="obtain-proof-option">
         <p>Enter tracking ID to download your proof of delivery.</p>
-        <form [formGroup]="trackingForm" (ngSubmit)="onSubmit()">
+        <form [formGroup]="trackingForm" (ngSubmit)="onDownloadProofClick()">
           <div class="tracking-form__input-group">
             <input type="text" formControlName="trackingNumber" class="tracking-form__input" placeholder="Enter tracking ID">
-            <button type="submit" class="tracking-form__btn">
+            <button type="button" class="tracking-form__btn" (click)="onDownloadProofClick()">
               <i class="fas fa-download"></i>
               Download Proof
             </button>

--- a/src/app/pages/home/components/hero/hero-section.component.ts
+++ b/src/app/pages/home/components/hero/hero-section.component.ts
@@ -16,6 +16,8 @@ export class HeroSectionComponent {
   @Output() submit = new EventEmitter<void>();
   @Output() selectFeature = new EventEmitter<'barcode_scan' | 'obtain_proof' | null>();
   @Output() barcodeSelected = new EventEmitter<any>();
+  @Output() proScan = new EventEmitter<void>();
+  @Output() downloadProof = new EventEmitter<void>();
 
   onSubmit() {
     this.submit.emit();
@@ -27,5 +29,13 @@ export class HeroSectionComponent {
 
   onBarcodeFileSelected(event: any) {
     this.barcodeSelected.emit(event);
+  }
+
+  onProScanClick() {
+    this.proScan.emit();
+  }
+
+  onDownloadProofClick() {
+    this.downloadProof.emit();
   }
 }

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -3,7 +3,9 @@
   [trackingForm]="trackingForm"
   (submit)="onSubmit()"
   (selectFeature)="selectHeroFeature($event)"
-  (barcodeSelected)="onBarcodeFileSelected($event)">
+  (barcodeSelected)="onBarcodeFileSelected($event)"
+  (proScan)="onProScan()"
+  (downloadProof)="onDownloadProof()">
 </app-hero-section>
 
 <app-services-section [servicesList]="servicesList"></app-services-section>

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -415,6 +415,19 @@ export class HomeComponent implements OnInit, OnDestroy {
     }
   }
 
+  onProScan(): void {
+    this.router.navigate(['/services/pro-scan']);
+  }
+
+  onDownloadProof(): void {
+    const trackingNumber = this.trackingForm.get('trackingNumber')?.value;
+    if (trackingNumber) {
+      this.router.navigate(['/services/proof', trackingNumber]);
+    } else {
+      this.router.navigate(['/services/proof']);
+    }
+  }
+
   // TODO: Ajouter la logique pour 'Obtain your proof' (saisie ID et bouton télécharger)
 
   // Method to generate barcode


### PR DESCRIPTION
## Summary
- emit `proScan` and `downloadProof` events from hero section
- wire up events in `HomeComponent` to navigate to service routes
- update hero HTML to trigger event handlers

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cec96e368832eab8ee17b3f00ef2c