### PR TITLE
Add forms for service pages

### DIFF
--- a/src/app/pages/services/generate-barcode.component.html
+++ b/src/app/pages/services/generate-barcode.component.html
@@ -1,4 +1,23 @@
 <section class="generate-barcode">
   <h2>Generate Barcode</h2>
-  <p>Create barcodes to easily identify your shipments.</p>
+  <p class="instructions">
+    Provide the text or tracking number you want to encode, then click generate to create a barcode you can print.
+  </p>
+
+  <form [formGroup]="barcodeForm" (ngSubmit)="onSubmit()">
+    <div class="form-group">
+      <label for="data">Text or tracking ID *</label>
+      <input id="data" type="text" formControlName="data" />
+      <span class="error" *ngIf="barcodeForm.get('data')?.invalid && barcodeForm.get('data')?.touched">
+        At least 5 characters are required.
+      </span>
+    </div>
+
+    <button type="submit" [disabled]="barcodeForm.invalid">Generate</button>
+  </form>
+
+  <div class="barcode-result" *ngIf="generatedData">
+    <p>Barcode data: <strong>{{ generatedData }}</strong></p>
+    <!-- Placeholder for barcode image -->
+  </div>
 </section>

--- a/src/app/pages/services/generate-barcode.component.scss
+++ b/src/app/pages/services/generate-barcode.component.scss
@@ -1,3 +1,45 @@
 .generate-barcode {
   padding: 1rem;
+
+  .form-group {
+    margin-bottom: 1rem;
+    display: flex;
+    flex-direction: column;
+
+    label {
+      font-weight: 600;
+      margin-bottom: 0.25rem;
+    }
+
+    input {
+      padding: 0.5rem;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+    }
+
+    .error {
+      color: #e74c3c;
+      font-size: 0.875rem;
+      margin-top: 0.25rem;
+    }
+  }
+
+  button {
+    padding: 0.5rem 1rem;
+    background-color: #4d148c;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+
+  .barcode-result {
+    margin-top: 1rem;
+    font-style: italic;
+  }
 }

--- a/src/app/pages/services/generate-barcode.component.ts
+++ b/src/app/pages/services/generate-barcode.component.ts
@@ -1,11 +1,33 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { NotificationService } from '../../shared/services/notification.service';
 
 @Component({
   selector: 'app-generate-barcode',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, ReactiveFormsModule],
   templateUrl: './generate-barcode.component.html',
   styleUrls: ['./generate-barcode.component.scss']
 })
-export class GenerateBarcodeComponent {}
+export class GenerateBarcodeComponent {
+  barcodeForm: FormGroup;
+  generatedData: string | null = null;
+
+  constructor(private fb: FormBuilder, private notificationService: NotificationService) {
+    this.barcodeForm = this.fb.group({
+      data: ['', [Validators.required, Validators.minLength(5)]]
+    });
+  }
+
+  onSubmit(): void {
+    if (this.barcodeForm.valid) {
+      this.generatedData = this.barcodeForm.value.data;
+      console.log('Barcode data:', this.generatedData);
+      this.notificationService.success('Barcode created', 'Use the generated barcode below.');
+    } else {
+      this.barcodeForm.markAllAsTouched();
+      this.notificationService.error('Invalid data', 'Please provide text to encode.');
+    }
+  }
+}

--- a/src/app/pages/services/notifications.component.html
+++ b/src/app/pages/services/notifications.component.html
@@ -1,4 +1,23 @@
 <section class="notifications">
   <h2>Notifications</h2>
-  <p>Stay informed of every update with instant alerts.</p>
+  <p class="instructions">
+    Sign up to receive shipment notifications by email or SMS.
+  </p>
+
+  <form [formGroup]="signupForm" (ngSubmit)="onSubmit()">
+    <div class="form-group">
+      <label for="email">Email *</label>
+      <input id="email" type="email" formControlName="email" />
+      <span class="error" *ngIf="signupForm.get('email')?.invalid && signupForm.get('email')?.touched">
+        Please enter a valid email.
+      </span>
+    </div>
+
+    <div class="form-group">
+      <label for="phone">Mobile number (optional)</label>
+      <input id="phone" type="tel" formControlName="phone" placeholder="e.g., +1 555 123 4567" />
+    </div>
+
+    <button type="submit" [disabled]="signupForm.invalid">Activate Notifications</button>
+  </form>
 </section>

--- a/src/app/pages/services/notifications.component.scss
+++ b/src/app/pages/services/notifications.component.scss
@@ -1,3 +1,40 @@
 .notifications {
   padding: 1rem;
+
+  .form-group {
+    margin-bottom: 1rem;
+    display: flex;
+    flex-direction: column;
+
+    label {
+      font-weight: 600;
+      margin-bottom: 0.25rem;
+    }
+
+    input {
+      padding: 0.5rem;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+    }
+
+    .error {
+      color: #e74c3c;
+      font-size: 0.875rem;
+      margin-top: 0.25rem;
+    }
+  }
+
+  button {
+    padding: 0.5rem 1rem;
+    background-color: #4d148c;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
 }

--- a/src/app/pages/services/notifications.component.ts
+++ b/src/app/pages/services/notifications.component.ts
@@ -1,11 +1,33 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { NotificationService } from '../../shared/services/notification.service';
 
 @Component({
   selector: 'app-notifications',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, ReactiveFormsModule],
   templateUrl: './notifications.component.html',
   styleUrls: ['./notifications.component.scss']
 })
-export class NotificationsComponent {}
+export class NotificationsComponent {
+  signupForm: FormGroup;
+
+  constructor(private fb: FormBuilder, private notificationService: NotificationService) {
+    this.signupForm = this.fb.group({
+      email: ['', [Validators.required, Validators.email]],
+      phone: ['']
+    });
+  }
+
+  onSubmit(): void {
+    if (this.signupForm.valid) {
+      console.log('Notification signup:', this.signupForm.value);
+      this.notificationService.success('Subscribed', 'You will now receive notifications.');
+      this.signupForm.reset();
+    } else {
+      this.signupForm.markAllAsTouched();
+      this.notificationService.error('Invalid form', 'Please provide a valid email.');
+    }
+  }
+}

--- a/src/app/pages/services/track-by-mail.component.html
+++ b/src/app/pages/services/track-by-mail.component.html
@@ -1,4 +1,26 @@
 <section class="track-by-mail">
   <h2>Track by Mail</h2>
-  <p>Receive shipment updates directly in your inbox.</p>
+  <p class="instructions">
+    Enter your tracking number and email address to receive shipping updates as soon as they are available.
+  </p>
+
+  <form [formGroup]="trackForm" (ngSubmit)="onSubmit()">
+    <div class="form-group">
+      <label for="trackingNumber">Tracking number *</label>
+      <input id="trackingNumber" type="text" formControlName="trackingNumber" />
+      <span class="error" *ngIf="trackForm.get('trackingNumber')?.invalid && trackForm.get('trackingNumber')?.touched">
+        A valid tracking number is required.
+      </span>
+    </div>
+
+    <div class="form-group">
+      <label for="email">Email *</label>
+      <input id="email" type="email" formControlName="email" />
+      <span class="error" *ngIf="trackForm.get('email')?.invalid && trackForm.get('email')?.touched">
+        Please enter a valid email address.
+      </span>
+    </div>
+
+    <button type="submit" [disabled]="trackForm.invalid">Subscribe</button>
+  </form>
 </section>

--- a/src/app/pages/services/track-by-mail.component.scss
+++ b/src/app/pages/services/track-by-mail.component.scss
@@ -1,3 +1,40 @@
 .track-by-mail {
   padding: 1rem;
+
+  .form-group {
+    margin-bottom: 1rem;
+    display: flex;
+    flex-direction: column;
+
+    label {
+      font-weight: 600;
+      margin-bottom: 0.25rem;
+    }
+
+    input {
+      padding: 0.5rem;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+    }
+
+    .error {
+      color: #e74c3c;
+      font-size: 0.875rem;
+      margin-top: 0.25rem;
+    }
+  }
+
+  button {
+    padding: 0.5rem 1rem;
+    background-color: #4d148c;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
 }

--- a/src/app/pages/services/track-by-mail.component.ts
+++ b/src/app/pages/services/track-by-mail.component.ts
@@ -1,11 +1,34 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { NotificationService } from '../../shared/services/notification.service';
 
 @Component({
   selector: 'app-track-by-mail',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, ReactiveFormsModule],
   templateUrl: './track-by-mail.component.html',
   styleUrls: ['./track-by-mail.component.scss']
 })
-export class TrackByMailComponent {}
+export class TrackByMailComponent {
+  trackForm: FormGroup;
+
+  constructor(private fb: FormBuilder, private notificationService: NotificationService) {
+    this.trackForm = this.fb.group({
+      trackingNumber: ['', [Validators.required, Validators.pattern('^[A-Z0-9]{8,}$')]],
+      email: ['', [Validators.required, Validators.email]]
+    });
+  }
+
+  onSubmit(): void {
+    if (this.trackForm.valid) {
+      const { email } = this.trackForm.value;
+      console.log('Track by mail request:', this.trackForm.value);
+      this.notificationService.success('Subscription confirmed', `Updates will be sent to ${email}`);
+      this.trackForm.reset();
+    } else {
+      this.trackForm.markAllAsTouched();
+      this.notificationService.error('Invalid form', 'Please correct the errors and try again.');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add reactive forms with validation to Track By Mail page
- build barcode generator form
- create notification sign-up form

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cec97cd08832e93c7888589aa9509