### PR TITLE
Load Google Maps API key from env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+# Local environment overrides
+src/environments/*.local.ts

--- a/README.md
+++ b/README.md
@@ -28,4 +28,21 @@ To get more help on the Angular CLI use `ng help` or go check out the [Angular C
 
 ## Google Maps API Key
 
-The home page integrates Google Maps for displaying locations. Replace `YOUR_GOOGLE_MAPS_API_KEY` in `src/index.html` with your actual API key.
+Google Maps is loaded dynamically using the key defined in the Angular environment files.
+
+1. Open `src/environments/environment.ts` (and `environment.prod.ts` for production) and set the `googleMapsApiKey` property.
+2. **Do not commit your real key.** You can create copies named `environment.local.ts` and `environment.prod.local.ts` containing the key and add them to version control ignore rules.
+
+```bash
+cp src/environments/environment.ts src/environments/environment.local.ts
+cp src/environments/environment.prod.ts src/environments/environment.prod.local.ts
+# edit the *.local.ts files to add your key
+```
+
+Add the following line to `.gitignore` to keep the local files private:
+
+```
+src/environments/*.local.ts
+```
+
+Update your build configuration if needed to use the local files. For simple development you can replace the original environment files manually before running `ng serve`.

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,14 +1,25 @@
-import { ApplicationConfig } from '@angular/core';
+import { ApplicationConfig, APP_INITIALIZER } from '@angular/core';
 import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { provideAnimations } from '@angular/platform-browser/animations';
 
 import { routes } from './app.routes';
+import { GoogleMapsLoaderService } from './shared/services/google-maps-loader.service';
+
+export function initializeGoogleMaps(loader: GoogleMapsLoaderService) {
+  return () => loader.load();
+}
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(routes, withComponentInputBinding()),
     provideHttpClient(),
-    provideAnimations()
+    provideAnimations(),
+    {
+      provide: APP_INITIALIZER,
+      useFactory: initializeGoogleMaps,
+      deps: [GoogleMapsLoaderService],
+      multi: true
+    }
   ]
 };

--- a/src/app/shared/services/google-maps-loader.service.ts
+++ b/src/app/shared/services/google-maps-loader.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { environment } from '../../../environments/environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GoogleMapsLoaderService {
+  private scriptLoadingPromise: Promise<void> | null = null;
+
+  load(): Promise<void> {
+    if (this.scriptLoadingPromise) {
+      return this.scriptLoadingPromise;
+    }
+
+    this.scriptLoadingPromise = new Promise<void>((resolve, reject) => {
+      if ((window as any).google && (window as any).google.maps) {
+        resolve();
+        return;
+      }
+
+      const script = document.createElement('script');
+      script.src = `https://maps.googleapis.com/maps/api/js?key=${environment.googleMapsApiKey}`;
+      script.async = true;
+      script.defer = true;
+      script.onload = () => resolve();
+      script.onerror = (err) => reject(err);
+      document.head.appendChild(script);
+    });
+
+    return this.scriptLoadingPromise;
+  }
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,6 @@
 export const environment = {
   production: true,
-  apiUrl: '/api'  // URL de l'API en production (relative à l'hôte)
-}; 
+  apiUrl: '/api',  // URL de l\'API en production (relative à l\'hôte)
+  // Google Maps API key for production
+  googleMapsApiKey: ''
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,6 @@
 export const environment = {
   production: false,
-  apiUrl: 'http://localhost:8000/api'
-}; 
+  apiUrl: 'http://localhost:8000/api',
+  // Google Maps API key used when loading the script dynamically
+  googleMapsApiKey: ''
+};

--- a/src/index.html
+++ b/src/index.html
@@ -11,8 +11,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
   <!-- Leaflet JavaScript -->
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
-  <!-- Google Maps JavaScript API -->
-  <script src="https://maps.googleapis.com/maps/api/js?key=YOUR_GOOGLE_MAPS_API_KEY"></script>
+  <!-- Google Maps script is loaded dynamically -->
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
## Summary
- inject Google Maps API key via environment.ts and environment.prod.ts
- load Google Maps API dynamically with GoogleMapsLoaderService
- initialize loader using `APP_INITIALIZER`
- update index.html to remove hard-coded script
- document how to keep API keys out of version control
- ignore local environment overrides

## Testing
- `npm test --silent` *(fails: No Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684ceca3ca3c832ea0aea25615790ca9