### PR TITLE
Add barcode decoding and proof download

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@fortawesome/free-regular-svg-icons": "^6.4.0",
         "@fortawesome/free-solid-svg-icons": "^6.4.0",
         "@types/leaflet": "^1.9.18",
+        "@zxing/library": "^0.20.0",
         "file-saver": "^2.0.5",
         "leaflet": "^1.9.4",
         "rxjs": "~7.8.0",
@@ -4442,6 +4443,28 @@
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/@zxing/library": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.20.0.tgz",
+      "integrity": "sha512-6Ev6rcqVjMakZFIDvbUf0dtpPGeZMTfyxYg4HkVWioWeN7cRcnUWT3bU6sdohc82O1nPXcjq6WiGfXX2Pnit6A==",
+      "license": "MIT",
+      "dependencies": {
+        "ts-custom-error": "^3.2.1"
+      },
+      "engines": {
+        "node": ">= 10.4.0"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "~0.9.0"
+      }
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "license": "(Unlicense OR Apache-2.0)",
+      "optional": true
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -13124,6 +13147,15 @@
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-custom-error": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "xlsx": "^0.18.5",
-    "zone.js": "~0.13.0"
+    "zone.js": "~0.13.0",
+    "@zxing/library": "^0.20.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^16.0.5",

--- a/src/app/features/tracking/components/all-tracking/all-tracking.component.spec.ts
+++ b/src/app/features/tracking/components/all-tracking/all-tracking.component.spec.ts
@@ -1,14 +1,19 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 
 import { AllTrackingComponent } from './all-tracking.component';
+import { TrackingService } from '../../services/tracking.service';
 
 describe('AllTrackingComponent', () => {
   let component: AllTrackingComponent;
   let fixture: ComponentFixture<AllTrackingComponent>;
+  let trackingService: jasmine.SpyObj<TrackingService>;
 
   beforeEach(async () => {
+    trackingService = jasmine.createSpyObj('TrackingService', ['getProofOfDelivery']);
     await TestBed.configureTestingModule({
-      imports: [AllTrackingComponent]
+      imports: [AllTrackingComponent],
+      providers: [{ provide: TrackingService, useValue: trackingService }]
     })
     .compileComponents();
     
@@ -19,5 +24,15 @@ describe('AllTrackingComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should call service on proof download', () => {
+    component.proofNumber = 'ABC123';
+    component.isProofValid = true;
+    const blob = new Blob();
+    trackingService.getProofOfDelivery.and.returnValue(of(blob));
+    const event = new Event('submit');
+    component.getProofOfDelivery(event);
+    expect(trackingService.getProofOfDelivery).toHaveBeenCalledWith('ABC123');
   });
 });

--- a/src/app/features/tracking/components/all-tracking/all-tracking.component.ts
+++ b/src/app/features/tracking/components/all-tracking/all-tracking.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
+import { TrackingService } from '../../services/tracking.service';
 
 // TODO: Backend - Create Tracking Interfaces
 interface TrackingRequest {
@@ -59,11 +60,7 @@ export class AllTrackingComponent implements OnInit {
   isTCNValid: boolean = false;
   isProofValid: boolean = false;
 
-  constructor(
-    // TODO: Inject services
-    // private trackingService: TrackingService,
-    // private notificationService: NotificationService
-  ) {}
+  constructor(private trackingService: TrackingService) {}
 
   ngOnInit(): void {
     this.checkDevice();
@@ -198,15 +195,22 @@ export class AllTrackingComponent implements OnInit {
     if (!this.isProofValid) return;
 
     this.isLoading = true;
-    try {
-      // TODO: Implement proof of delivery download
-      console.log('Getting proof of delivery for:', this.proofNumber);
-      alert(`Téléchargement de la preuve de livraison pour: ${this.proofNumber}\n\n(Intégration API à venir)`);
-    } catch (error) {
-      console.error('Proof of delivery error:', error);
-    } finally {
-      this.isLoading = false;
-    }
+    this.trackingService.getProofOfDelivery(this.proofNumber).subscribe({
+      next: blob => {
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `proof-${this.proofNumber}.pdf`;
+        a.click();
+        window.URL.revokeObjectURL(url);
+      },
+      error: err => {
+        console.error('Proof of delivery error:', err);
+      },
+      complete: () => {
+        this.isLoading = false;
+      }
+    });
   }
 }
 

--- a/src/app/features/tracking/services/tracking.service.ts
+++ b/src/app/features/tracking/services/tracking.service.ts
@@ -162,4 +162,17 @@ export class TrackingService {
       })
     );
   }
-} 
+
+  getProofOfDelivery(trackingNumber: string): Observable<Blob> {
+    if (!trackingNumber || !trackingNumber.trim()) {
+      return throwError(() => new Error('Numéro de suivi invalide'));
+    }
+    const url = `${this.apiUrl}/tracking/proof/${encodeURIComponent(trackingNumber)}`;
+    return this.http.get(url, { responseType: 'blob' }).pipe(
+      catchError(error => {
+        console.error('Error fetching proof of delivery:', error);
+        return throwError(() => new Error('Erreur lors du téléchargement de la preuve de livraison'));
+      })
+    );
+  }
+}

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -1,14 +1,30 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { Router } from '@angular/router';
 
 import { HomeComponent } from './home.component';
+import { BarcodeReaderService } from '../../shared/services/barcode-reader.service';
+import { TrackingService } from '../../features/tracking/services/tracking.service';
 
 describe('HomeComponent', () => {
   let component: HomeComponent;
   let fixture: ComponentFixture<HomeComponent>;
+  let barcodeService: jasmine.SpyObj<BarcodeReaderService>;
+  let trackingService: jasmine.SpyObj<TrackingService>;
+  let router: jasmine.SpyObj<Router>;
 
   beforeEach(async () => {
+    barcodeService = jasmine.createSpyObj('BarcodeReaderService', ['decodeBarcode']);
+    trackingService = jasmine.createSpyObj('TrackingService', ['getProofOfDelivery']);
+    router = jasmine.createSpyObj('Router', ['navigate']);
+
     await TestBed.configureTestingModule({
-      imports: [HomeComponent]
+      imports: [HomeComponent],
+      providers: [
+        { provide: BarcodeReaderService, useValue: barcodeService },
+        { provide: TrackingService, useValue: trackingService },
+        { provide: Router, useValue: router }
+      ]
     })
     .compileComponents();
 
@@ -19,5 +35,15 @@ describe('HomeComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should decode barcode and navigate', async () => {
+    const file = new File(['dummy'], 'code.png');
+    barcodeService.decodeBarcode.and.returnValue(Promise.resolve('ZX123'));
+    const event = { target: { files: [file] } } as any;
+    component.onBarcodeFileSelected(event);
+    await fixture.whenStable();
+    expect(barcodeService.decodeBarcode).toHaveBeenCalledWith(file);
+    expect(router.navigate).toHaveBeenCalledWith(['/tracking', 'ZX123']);
   });
 });

--- a/src/app/shared/services/barcode-reader.service.spec.ts
+++ b/src/app/shared/services/barcode-reader.service.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed } from '@angular/core/testing';
+import { BarcodeReaderService } from './barcode-reader.service';
+import { BrowserBarcodeReader, Result } from '@zxing/library';
+
+describe('BarcodeReaderService', () => {
+  let service: BarcodeReaderService;
+  let mockReader: jasmine.SpyObj<BrowserBarcodeReader>;
+
+  beforeEach(() => {
+    mockReader = jasmine.createSpyObj('BrowserBarcodeReader', ['decodeFromImageUrl']);
+    TestBed.configureTestingModule({
+      providers: [BarcodeReaderService, { provide: BrowserBarcodeReader, useValue: mockReader }]
+    });
+    service = TestBed.inject(BarcodeReaderService);
+    (service as any).reader = mockReader;
+  });
+
+  it('should decode barcode from file', async () => {
+    const fakeResult = { getText: () => 'CODE123' } as Result;
+    mockReader.decodeFromImageUrl.and.returnValue(Promise.resolve(fakeResult));
+    const file = new File(['dummy'], 'code.png');
+    await expectAsync(service.decodeBarcode(file)).toBeResolvedTo('CODE123');
+  });
+});

--- a/src/app/shared/services/barcode-reader.service.ts
+++ b/src/app/shared/services/barcode-reader.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { BrowserBarcodeReader } from '@zxing/library';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BarcodeReaderService {
+  private reader = new BrowserBarcodeReader();
+
+  async decodeBarcode(file: File): Promise<string> {
+    const url = URL.createObjectURL(file);
+    try {
+      const result = await this.reader.decodeFromImageUrl(url);
+      return result.getText();
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- integrate `@zxing/library` for barcode decoding
- decode barcode image upload and fetch tracking data
- enable proof of delivery download from tracking service
- add barcode reader service with unit tests
- extend component tests for new flows

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684cecaaa8b4832eb2eadb2d8cf4d2b7