### PR TITLE
Load Google Maps dynamically

### DIFF
--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -18,6 +18,7 @@ import { LocationsSectionComponent } from './components/locations/locations-sect
 import { FaqSectionComponent } from './components/faq/faq-section.component';
 import { CtaSectionComponent } from './components/cta/cta-section.component';
 import { NotificationsComponent } from './components/notifications/notifications.component';
+import { MapLoaderService } from '../../shared/services/map-loader.service';
 
 // Import Google Maps types
 declare global {
@@ -98,7 +99,8 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   constructor(
     private fb: FormBuilder,
-    private router: Router
+    private router: Router,
+    private mapLoader: MapLoaderService
   ) {
     this.trackingForm = this.fb.group({
       trackingNumber: ['', [Validators.required, Validators.pattern('^[A-Z0-9]{10,}$')]]
@@ -116,10 +118,16 @@ export class HomeComponent implements OnInit, OnDestroy {
     this.initializeFAQ();
     this.initializeServices();
     
-    // Initialize map after a short delay to ensure DOM is ready
-    setTimeout(() => {
-      this.initializeMap();
-    }, 1000);
+    this.mapLoader.load()
+      .then(() => {
+        // Initialize map after a short delay to ensure DOM is ready
+        setTimeout(() => {
+          this.initializeMap();
+        }, 1000);
+      })
+      .catch(err => {
+        console.error('Failed to load Google Maps', err);
+      });
   }
 
   ngOnDestroy() {

--- a/src/app/shared/services/map-loader.service.ts
+++ b/src/app/shared/services/map-loader.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { environment } from '../../../environments/environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MapLoaderService {
+  private loadingPromise: Promise<void> | null = null;
+
+  load(): Promise<void> {
+    if (this.loadingPromise) {
+      return this.loadingPromise;
+    }
+
+    if (typeof window !== 'undefined' && (window as any).google && (window as any).google.maps) {
+      return Promise.resolve();
+    }
+
+    const script = document.createElement('script');
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${environment.googleMapsApiKey}`;
+    script.async = true;
+    script.defer = true;
+
+    this.loadingPromise = new Promise<void>((resolve, reject) => {
+      script.onload = () => resolve();
+      script.onerror = (err) => reject(err);
+    });
+
+    document.head.appendChild(script);
+    return this.loadingPromise;
+  }
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
-  apiUrl: '/api'  // URL de l'API en production (relative à l'hôte)
-}; 
+  apiUrl: '/api',  // URL de l'API en production (relative à l\'hôte)
+  googleMapsApiKey: 'YOUR_GOOGLE_MAPS_API_KEY'
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: false,
-  apiUrl: 'http://localhost:8000/api'
-}; 
+  apiUrl: 'http://localhost:8000/api',
+  googleMapsApiKey: 'YOUR_GOOGLE_MAPS_API_KEY'
+};

--- a/src/index.html
+++ b/src/index.html
@@ -11,8 +11,6 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
   <!-- Leaflet JavaScript -->
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
-  <!-- Google Maps JavaScript API -->
-  <script src="https://maps.googleapis.com/maps/api/js?key=YOUR_GOOGLE_MAPS_API_KEY"></script>
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
## Summary
- add `googleMapsApiKey` to environment files
- create `MapLoaderService` to load Google Maps at runtime
- remove hardcoded Google Maps `<script>` tag
- use the new service in `HomeComponent`

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_684cec94f978832e82c49c00e97fab9f