### PR TITLE
Add router navigation for tracking result

### DIFF
--- a/src/app/features/tracking/components/all-tracking/all-tracking.component.spec.ts
+++ b/src/app/features/tracking/components/all-tracking/all-tracking.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { AllTrackingComponent } from './all-tracking.component';
 
@@ -8,7 +9,7 @@ describe('AllTrackingComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AllTrackingComponent]
+      imports: [RouterTestingModule, AllTrackingComponent]
     })
     .compileComponents();
     

--- a/src/app/features/tracking/components/all-tracking/all-tracking.component.ts
+++ b/src/app/features/tracking/components/all-tracking/all-tracking.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { RouterModule } from '@angular/router';
+import { RouterModule, Router } from '@angular/router';
 
 // TODO: Backend - Create Tracking Interfaces
 interface TrackingRequest {
@@ -60,6 +60,7 @@ export class AllTrackingComponent implements OnInit {
   isProofValid: boolean = false;
 
   constructor(
+    private router: Router,
     // TODO: Inject services
     // private trackingService: TrackingService,
     // private notificationService: NotificationService
@@ -147,6 +148,12 @@ export class AllTrackingComponent implements OnInit {
       // Simulation for development
       console.log('Tracking package:', this.trackingNumber);
       alert(`Recherche du colis: ${this.trackingNumber}\n\n(Intégration API à venir)`);
+      this.router.navigate(['/tracking/result'], {
+        queryParams: {
+          number: this.trackingNumber,
+          type: 'number'
+        }
+      });
     } catch (error) {
       console.error('Tracking error:', error);
       // this.notificationService.error('Failed to retrieve tracking information');
@@ -162,11 +169,17 @@ export class AllTrackingComponent implements OnInit {
     this.isLoading = true;
     try {
       // TODO: Implement reference tracking
-      console.log('Tracking by reference:', { 
-        reference: this.referenceNumber, 
-        country: this.selectedCountry 
+      console.log('Tracking by reference:', {
+        reference: this.referenceNumber,
+        country: this.selectedCountry
       });
       alert(`Recherche par référence: ${this.referenceNumber}\nPays: ${this.selectedCountry}\n\n(Intégration API à venir)`);
+      this.router.navigate(['/tracking/result'], {
+        queryParams: {
+          number: this.referenceNumber,
+          type: 'reference'
+        }
+      });
     } catch (error) {
       console.error('Reference tracking error:', error);
     } finally {
@@ -181,11 +194,17 @@ export class AllTrackingComponent implements OnInit {
     this.isLoading = true;
     try {
       // TODO: Implement TCN tracking
-      console.log('Tracking by TCN:', { 
-        tcn: this.tcnNumber, 
-        shipDate: this.shipDate 
+      console.log('Tracking by TCN:', {
+        tcn: this.tcnNumber,
+        shipDate: this.shipDate
       });
       alert(`Recherche TCN: ${this.tcnNumber}\nDate: ${this.shipDate}\n\n(Intégration API à venir)`);
+      this.router.navigate(['/tracking/result'], {
+        queryParams: {
+          number: this.tcnNumber,
+          type: 'tcn'
+        }
+      });
     } catch (error) {
       console.error('TCN tracking error:', error);
     } finally {


### PR DESCRIPTION
## Summary
- inject `Router` into `AllTrackingComponent`
- navigate to tracking results when a tracking search succeeds
- update tests with `RouterTestingModule`

## Testing
- `npm install`
- `npm test` *(fails: Chrome binary not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf169b224832ea4f238524b84fef6