### PR TITLE
Add tests for tracking result forms

### DIFF
--- a/src/app/features/tracking/components/tracking-result/tracking-result.component.html
+++ b/src/app/features/tracking/components/tracking-result/tracking-result.component.html
@@ -299,7 +299,7 @@
                 </div>
                 <div class="form-actions">
                     <button type="button" class="btn btn-secondary" (click)="closeAllModals()">Annuler</button>
-                    <button type="submit" class="btn btn-primary">Confirmer</button>
+                    <button type="submit" class="btn btn-primary" [disabled]="!scheduleForm.date || !scheduleForm.timeWindow">Confirmer</button>
                 </div>
             </form>
         </div>
@@ -341,7 +341,7 @@
                 </div>
                 <div class="form-actions">
                     <button type="button" class="btn btn-secondary" (click)="closeAllModals()">Annuler</button>
-                    <button type="submit" class="btn btn-primary">Confirmer</button>
+                    <button type="submit" class="btn btn-primary" [disabled]="!addressForm.name || !addressForm.line1 || !addressForm.city || !addressForm.postalCode">Confirmer</button>
                 </div>
             </form>
         </div>

--- a/src/app/features/tracking/components/tracking-result/tracking-result.component.spec.ts
+++ b/src/app/features/tracking/components/tracking-result/tracking-result.component.spec.ts
@@ -1,0 +1,105 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
+import { TrackingResultComponent } from './tracking-result.component';
+import { TrackingService } from '../../services/tracking.service';
+import { NotificationService } from '../../../../shared/services/notification.service';
+
+describe('TrackingResultComponent', () => {
+  let component: TrackingResultComponent;
+  let fixture: ComponentFixture<TrackingResultComponent>;
+  let trackingService: jasmine.SpyObj<TrackingService>;
+  let notificationService: jasmine.SpyObj<NotificationService>;
+
+  beforeEach(async () => {
+    const trackingSpy = jasmine.createSpyObj('TrackingService', ['updateDeliveryOptions']);
+    const notifSpy = jasmine.createSpyObj('NotificationService', ['success', 'error']);
+
+    await TestBed.configureTestingModule({
+      imports: [TrackingResultComponent],
+      providers: [
+        { provide: TrackingService, useValue: trackingSpy },
+        { provide: NotificationService, useValue: notifSpy },
+        { provide: ActivatedRoute, useValue: { queryParams: of({}) } }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TrackingResultComponent);
+    component = fixture.componentInstance;
+    trackingService = TestBed.inject(TrackingService) as jasmine.SpyObj<TrackingService>;
+    notificationService = TestBed.inject(NotificationService) as jasmine.SpyObj<NotificationService>;
+    component.trackingNumber = 'GBX123456';
+    fixture.detectChanges();
+  });
+
+  it('should submit schedule form', () => {
+    trackingService.updateDeliveryOptions.and.returnValue(of({}));
+    component.scheduleForm.date = '2025-06-20';
+    component.scheduleForm.timeWindow = 'morning';
+
+    component.saveScheduleDelivery();
+
+    expect(trackingService.updateDeliveryOptions).toHaveBeenCalledWith('GBX123456', { schedule: component.scheduleForm });
+    expect(notificationService.success).toHaveBeenCalled();
+  });
+
+  it('should submit address form', () => {
+    trackingService.updateDeliveryOptions.and.returnValue(of({}));
+    component.addressForm = {
+      name: 'John',
+      line1: '1 st',
+      line2: '',
+      city: 'NY',
+      postalCode: '12345',
+      country: 'MA',
+      phone: ''
+    };
+
+    component.saveAddressChange();
+
+    expect(trackingService.updateDeliveryOptions).toHaveBeenCalledWith('GBX123456', { address: component.addressForm });
+    expect(notificationService.success).toHaveBeenCalled();
+  });
+
+  it('should submit location form', () => {
+    trackingService.updateDeliveryOptions.and.returnValue(of({}));
+    component.locationForm.selectedId = 'loc1';
+
+    component.saveHoldLocation();
+
+    expect(trackingService.updateDeliveryOptions).toHaveBeenCalledWith('GBX123456', { holdLocation: 'loc1' });
+    expect(notificationService.success).toHaveBeenCalled();
+  });
+
+  it('should submit instructions form', () => {
+    trackingService.updateDeliveryOptions.and.returnValue(of({}));
+    component.instructionsForm = { type: 'leave-at-door', accessCode: '', details: '' };
+
+    component.saveDeliveryInstructions();
+
+    expect(trackingService.updateDeliveryOptions).toHaveBeenCalledWith('GBX123456', { instructions: component.instructionsForm });
+    expect(notificationService.success).toHaveBeenCalled();
+  });
+
+  it('should disable schedule button when required fields missing', () => {
+    component.showScheduleModal = true;
+    fixture.detectChanges();
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('.modal.show button.btn-primary');
+    expect(button.disabled).toBeTrue();
+  });
+
+  it('should disable address button when required fields missing', () => {
+    component.showAddressModal = true;
+    fixture.detectChanges();
+    const buttons = fixture.nativeElement.querySelectorAll('.modal.show button.btn-primary');
+    const addressButton = buttons[buttons.length - 1] as HTMLButtonElement;
+    expect(addressButton.disabled).toBeTrue();
+  });
+
+  it('should disable hold location button when none selected', () => {
+    component.showLocationModal = true;
+    fixture.detectChanges();
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('.modal.show button.btn-primary');
+    expect(button.disabled).toBeTrue();
+  });
+});

--- a/src/app/features/tracking/components/tracking-result/tracking-result.component.ts
+++ b/src/app/features/tracking/components/tracking-result/tracking-result.component.ts
@@ -5,6 +5,7 @@ import { FormsModule } from '@angular/forms';
 import { NgClass, NgIf, NgFor, NgStyle } from '@angular/common';
 import { TrackingData } from '../../models/tracking-data.model';
 import { TrackingService } from '../../services/tracking.service';
+import { NotificationService } from '../../../../shared/services/notification.service';
 
 // Declare Leaflet to avoid TypeScript errors
 declare const L: any;
@@ -108,7 +109,8 @@ export class TrackingResultComponent implements OnInit, AfterViewInit {
 
   constructor(
     private route: ActivatedRoute,
-    private trackingService: TrackingService
+    private trackingService: TrackingService,
+    private notificationService: NotificationService
   ) { }
 
   ngOnInit(): void {
@@ -328,59 +330,67 @@ export class TrackingResultComponent implements OnInit, AfterViewInit {
   
   // ==== FORM SUBMISSION METHODS ====
   saveScheduleDelivery(): void {
-    // This would call an API endpoint to update delivery schedule
-    console.log('Schedule data to submit:', this.scheduleForm);
-    
-    // Simulate API call
-    setTimeout(() => {
-      alert('Delivery has been scheduled successfully!');
-      this.closeAllModals();
-      this.loadTrackingData(); // Refresh tracking data
-    }, 1000);
+    this.trackingService.updateDeliveryOptions(this.trackingNumber, { schedule: this.scheduleForm })
+      .subscribe({
+        next: () => {
+          this.notificationService.success('Delivery scheduled', 'Your delivery has been scheduled.');
+          this.closeAllModals();
+          this.loadTrackingData();
+        },
+        error: () => {
+          this.notificationService.error('Error', 'Could not schedule delivery.');
+        }
+      });
   }
   
   saveAddressChange(): void {
-    // Validate form
     if (!this.addressForm.name || !this.addressForm.line1 || !this.addressForm.city || !this.addressForm.postalCode) {
-      alert('Please fill in all required fields');
       return;
     }
-    
-    console.log('Address data to submit:', this.addressForm);
-    
-    // Simulate API call
-    setTimeout(() => {
-      alert('Delivery address has been updated successfully!');
-      this.closeAllModals();
-      this.loadTrackingData(); // Refresh tracking data
-    }, 1000);
+
+    this.trackingService.updateDeliveryOptions(this.trackingNumber, { address: this.addressForm })
+      .subscribe({
+        next: () => {
+          this.notificationService.success('Address updated', 'Delivery address has been updated successfully.');
+          this.closeAllModals();
+          this.loadTrackingData();
+        },
+        error: () => {
+          this.notificationService.error('Error', 'Could not update address.');
+        }
+      });
   }
   
   saveHoldLocation(): void {
     if (!this.locationForm.selectedId) {
-      alert('Please select a location');
       return;
     }
-    
-    console.log('Location data to submit:', this.locationForm);
-    
-    // Simulate API call
-    setTimeout(() => {
-      alert('Package will be held at the selected location');
-      this.closeAllModals();
-      this.loadTrackingData(); // Refresh tracking data
-    }, 1000);
+
+    this.trackingService.updateDeliveryOptions(this.trackingNumber, { holdLocation: this.locationForm.selectedId })
+      .subscribe({
+        next: () => {
+          this.notificationService.success('Location selected', 'Package will be held at the selected location.');
+          this.closeAllModals();
+          this.loadTrackingData();
+        },
+        error: () => {
+          this.notificationService.error('Error', 'Could not update hold location.');
+        }
+      });
   }
   
   saveDeliveryInstructions(): void {
-    console.log('Instructions data to submit:', this.instructionsForm);
-    
-    // Simulate API call
-    setTimeout(() => {
-      alert('Delivery instructions have been saved');
-      this.closeAllModals();
-      this.loadTrackingData(); // Refresh tracking data
-    }, 1000);
+    this.trackingService.updateDeliveryOptions(this.trackingNumber, { instructions: this.instructionsForm })
+      .subscribe({
+        next: () => {
+          this.notificationService.success('Instructions saved', 'Delivery instructions have been saved.');
+          this.closeAllModals();
+          this.loadTrackingData();
+        },
+        error: () => {
+          this.notificationService.error('Error', 'Could not save instructions.');
+        }
+      });
   }
   
   searchLocations(): void {


### PR DESCRIPTION
## Summary
- inject NotificationService into `TrackingResultComponent`
- call `TrackingService.updateDeliveryOptions` in form methods
- disable confirm buttons unless forms are valid
- add `TrackingResultComponent` unit tests

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf1673f28832e9acf03270050db79