### PR TITLE
Refactor tracking forms

### DIFF
--- a/src/app/features/tracking/components/all-tracking/all-tracking.component.html
+++ b/src/app/features/tracking/components/all-tracking/all-tracking.component.html
@@ -54,17 +54,15 @@
           Enter up to 30 of your Globex tracking, door tag, or Globex Office order numbers (one per line).
         </p>
         
-        <form class="tracking-form" (ngSubmit)="trackPackage($event)">
+        <form [formGroup]="trackingForm" class="tracking-form" (ngSubmit)="trackPackage()">
           <div class="form-group">
             <label class="form-label" for="trackingInput">Tracking number*</label>
-            <input 
-              type="text" 
+            <input
+              type="text"
               id="trackingInput"
-              class="form-input" 
+              class="form-input"
               placeholder="Enter tracking number"
-              [(ngModel)]="trackingNumber"
-              name="trackingNumber"
-              (input)="validateInput('tracking', trackingNumber)"
+              formControlName="trackingNumber"
             >
           </div>
 
@@ -92,8 +90,8 @@
             <button 
               type="submit" 
               class="track-btn" 
-              [class.enabled]="isTrackingValid"
-              [disabled]="!isTrackingValid || isLoading">
+              [class.enabled]="trackingForm.valid"
+              [disabled]="trackingForm.invalid || isLoading">
               <span *ngIf="!isLoading">TRACK</span>
               <span *ngIf="isLoading">TRACKING...</span>
             </button>
@@ -107,28 +105,24 @@
           Enter your reference number or purchase order numbers.
         </p>
         
-        <form class="tracking-form" (ngSubmit)="trackByReference($event)">
+        <form [formGroup]="referenceForm" class="tracking-form" (ngSubmit)="trackByReference()">
           <div class="form-group">
             <label class="form-label" for="referenceInput">Reference number*</label>
-            <input 
-              type="text" 
+            <input
+              type="text"
               id="referenceInput"
-              class="form-input" 
+              class="form-input"
               placeholder="Enter reference number"
-              [(ngModel)]="referenceNumber"
-              name="referenceNumber"
-              (input)="validateInput('reference', referenceNumber)"
+              formControlName="referenceNumber"
             >
           </div>
           
           <div class="form-group">
             <label class="form-label" for="countrySelect">Destination country/territory*</label>
-            <select 
-              id="countrySelect" 
+            <select
+              id="countrySelect"
               class="form-select"
-              [(ngModel)]="selectedCountry"
-              name="selectedCountry"
-              (change)="validateInput('reference', referenceNumber)">
+              formControlName="selectedCountry">
               <option value="">Select country</option>
               <option value="FR">France</option>
               <option value="DE">Germany</option>
@@ -145,8 +139,8 @@
             <button 
               type="submit" 
               class="track-btn" 
-              [class.enabled]="isReferenceValid"
-              [disabled]="!isReferenceValid || isLoading">
+              [class.enabled]="referenceForm.valid"
+              [disabled]="referenceForm.invalid || isLoading">
               <span *ngIf="!isLoading">TRACK</span>
               <span *ngIf="isLoading">TRACKING...</span>
             </button>
@@ -161,17 +155,15 @@
           Do not use any spaces or the letters "TCN" preceding the number.
         </p>
         
-        <form class="tracking-form" (ngSubmit)="trackByTCN($event)">
+        <form [formGroup]="tcnForm" class="tracking-form" (ngSubmit)="trackByTCN()">
           <div class="form-group">
             <label class="form-label" for="tcnInput">Enter TCN or tracking number*</label>
-            <input 
-              type="text" 
+            <input
+              type="text"
               id="tcnInput"
-              class="form-input" 
+              class="form-input"
               placeholder="Enter TCN"
-              [(ngModel)]="tcnNumber"
-              name="tcnNumber"
-              (input)="validateInput('tcn', tcnNumber)"
+              formControlName="tcnNumber"
             >
           </div>
           
@@ -182,10 +174,8 @@
                 type="date" 
                 id="shipDate"
                 class="form-input"
-                [(ngModel)]="shipDate"
-                name="shipDate"
-                (change)="validateInput('tcn', tcnNumber)"
-              >
+                formControlName="shipDate"
+            >
               <i class="fas fa-calendar" style="position: absolute; right: 15px; top: 50%; transform: translateY(-50%); color: #4d148c; pointer-events: none;"></i>
             </div>
             <div class="form-help">Please enter the ship date if the package was shipped more than 14 days ago.</div>
@@ -197,8 +187,8 @@
             <button 
               type="submit" 
               class="track-btn" 
-              [class.enabled]="isTCNValid"
-              [disabled]="!isTCNValid || isLoading">
+              [class.enabled]="tcnForm.valid"
+              [disabled]="tcnForm.invalid || isLoading">
               <span *ngIf="!isLoading">TRACK</span>
               <span *ngIf="isLoading">TRACKING...</span>
             </button>
@@ -208,17 +198,15 @@
 
       <!-- Proof of Delivery -->
       <div class="tracking-panel" [class.active]="activeTab === 'proof-delivery'">
-        <form class="tracking-form" (ngSubmit)="getProofOfDelivery($event)">
+        <form [formGroup]="proofForm" class="tracking-form" (ngSubmit)="getProofOfDelivery()">
           <div class="form-group">
             <label class="form-label" for="proofInput">Tracking ID*</label>
-            <input 
-              type="text" 
+            <input
+              type="text"
               id="proofInput"
-              class="form-input" 
+              class="form-input"
               placeholder="Enter your tracking ID"
-              [(ngModel)]="proofNumber"
-              name="proofNumber"
-              (input)="validateInput('proof', proofNumber)"
+              formControlName="proofNumber"
             >
           </div>
           
@@ -226,8 +214,8 @@
             <button 
               type="submit" 
               class="track-btn enabled" 
-              [class.enabled]="isProofValid"
-              [disabled]="!isProofValid || isLoading">
+              [class.enabled]="proofForm.valid"
+              [disabled]="proofForm.invalid || isLoading">
               <span *ngIf="!isLoading">DOWNLOAD</span>
               <span *ngIf="isLoading">DOWNLOADING...</span>
             </button>


### PR DESCRIPTION
## Summary
- convert tracking search forms to reactive forms
- wire forms to `FormGroup` instances with validators
- update template to use `formControlName` bindings

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_684cf162f0f8832ebfd0b1584416466d