### PR TITLE
Enable reactive forms in tracking

### DIFF
--- a/src/app/features/tracking/components/all-tracking/all-tracking.component.html
+++ b/src/app/features/tracking/components/all-tracking/all-tracking.component.html
@@ -54,7 +54,7 @@
           Enter up to 30 of your Globex tracking, door tag, or Globex Office order numbers (one per line).
         </p>
         
-        <form class="tracking-form" (ngSubmit)="trackPackage($event)">
+        <form class="tracking-form" [formGroup]="trackingForm" (ngSubmit)="trackPackage($event)">
           <div class="form-group">
             <label class="form-label" for="trackingInput">Tracking number*</label>
             <input 
@@ -62,10 +62,11 @@
               id="trackingInput"
               class="form-input" 
               placeholder="Enter tracking number"
-              [(ngModel)]="trackingNumber"
-              name="trackingNumber"
-              (input)="validateInput('tracking', trackingNumber)"
+              formControlName="trackingNumber"
             >
+            <div class="error" *ngIf="trackingForm.get('trackingNumber')?.touched && trackingForm.get('trackingNumber')?.invalid">
+              Tracking number is required and must be at least 8 alphanumeric characters.
+            </div>
           </div>
 
           <!-- ===== SCAN BARCODE SECTION ===== -->
@@ -91,9 +92,9 @@
           <div style="text-align: center;">
             <button 
               type="submit" 
-              class="track-btn" 
-              [class.enabled]="isTrackingValid"
-              [disabled]="!isTrackingValid || isLoading">
+              class="track-btn"
+              [class.enabled]="trackingForm.valid"
+              [disabled]="!trackingForm.valid || isLoading">
               <span *ngIf="!isLoading">TRACK</span>
               <span *ngIf="isLoading">TRACKING...</span>
             </button>
@@ -107,7 +108,7 @@
           Enter your reference number or purchase order numbers.
         </p>
         
-        <form class="tracking-form" (ngSubmit)="trackByReference($event)">
+        <form class="tracking-form" [formGroup]="referenceForm" (ngSubmit)="trackByReference($event)">
           <div class="form-group">
             <label class="form-label" for="referenceInput">Reference number*</label>
             <input 
@@ -115,10 +116,11 @@
               id="referenceInput"
               class="form-input" 
               placeholder="Enter reference number"
-              [(ngModel)]="referenceNumber"
-              name="referenceNumber"
-              (input)="validateInput('reference', referenceNumber)"
+              formControlName="referenceNumber"
             >
+            <div class="error" *ngIf="referenceForm.get('referenceNumber')?.touched && referenceForm.get('referenceNumber')?.invalid">
+              Reference number is required and must be at least 3 characters.
+            </div>
           </div>
           
           <div class="form-group">
@@ -126,9 +128,7 @@
             <select 
               id="countrySelect" 
               class="form-select"
-              [(ngModel)]="selectedCountry"
-              name="selectedCountry"
-              (change)="validateInput('reference', referenceNumber)">
+              formControlName="selectedCountry">
               <option value="">Select country</option>
               <option value="FR">France</option>
               <option value="DE">Germany</option>
@@ -145,8 +145,8 @@
             <button 
               type="submit" 
               class="track-btn" 
-              [class.enabled]="isReferenceValid"
-              [disabled]="!isReferenceValid || isLoading">
+              [class.enabled]="referenceForm.valid"
+              [disabled]="!referenceForm.valid || isLoading">
               <span *ngIf="!isLoading">TRACK</span>
               <span *ngIf="isLoading">TRACKING...</span>
             </button>
@@ -161,7 +161,7 @@
           Do not use any spaces or the letters "TCN" preceding the number.
         </p>
         
-        <form class="tracking-form" (ngSubmit)="trackByTCN($event)">
+        <form class="tracking-form" [formGroup]="tcnForm" (ngSubmit)="trackByTCN($event)">
           <div class="form-group">
             <label class="form-label" for="tcnInput">Enter TCN or tracking number*</label>
             <input 
@@ -169,10 +169,11 @@
               id="tcnInput"
               class="form-input" 
               placeholder="Enter TCN"
-              [(ngModel)]="tcnNumber"
-              name="tcnNumber"
-              (input)="validateInput('tcn', tcnNumber)"
+              formControlName="tcnNumber"
             >
+            <div class="error" *ngIf="tcnForm.get('tcnNumber')?.touched && tcnForm.get('tcnNumber')?.invalid">
+              TCN is required and must be at least 6 characters.
+            </div>
           </div>
           
           <div class="form-group">
@@ -182,9 +183,7 @@
                 type="date" 
                 id="shipDate"
                 class="form-input"
-                [(ngModel)]="shipDate"
-                name="shipDate"
-                (change)="validateInput('tcn', tcnNumber)"
+                formControlName="shipDate"
               >
               <i class="fas fa-calendar" style="position: absolute; right: 15px; top: 50%; transform: translateY(-50%); color: #4d148c; pointer-events: none;"></i>
             </div>
@@ -197,8 +196,8 @@
             <button 
               type="submit" 
               class="track-btn" 
-              [class.enabled]="isTCNValid"
-              [disabled]="!isTCNValid || isLoading">
+              [class.enabled]="tcnForm.valid"
+              [disabled]="!tcnForm.valid || isLoading">
               <span *ngIf="!isLoading">TRACK</span>
               <span *ngIf="isLoading">TRACKING...</span>
             </button>
@@ -208,7 +207,7 @@
 
       <!-- Proof of Delivery -->
       <div class="tracking-panel" [class.active]="activeTab === 'proof-delivery'">
-        <form class="tracking-form" (ngSubmit)="getProofOfDelivery($event)">
+        <form class="tracking-form" [formGroup]="proofForm" (ngSubmit)="getProofOfDelivery($event)">
           <div class="form-group">
             <label class="form-label" for="proofInput">Tracking ID*</label>
             <input 
@@ -216,18 +215,19 @@
               id="proofInput"
               class="form-input" 
               placeholder="Enter your tracking ID"
-              [(ngModel)]="proofNumber"
-              name="proofNumber"
-              (input)="validateInput('proof', proofNumber)"
+              formControlName="proofNumber"
             >
+            <div class="error" *ngIf="proofForm.get('proofNumber')?.touched && proofForm.get('proofNumber')?.invalid">
+              Tracking ID is required and must be at least 8 characters.
+            </div>
           </div>
           
           <div style="text-align: center;">
             <button 
               type="submit" 
-              class="track-btn enabled" 
-              [class.enabled]="isProofValid"
-              [disabled]="!isProofValid || isLoading">
+              class="track-btn enabled"
+              [class.enabled]="proofForm.valid"
+              [disabled]="!proofForm.valid || isLoading">
               <span *ngIf="!isLoading">DOWNLOAD</span>
               <span *ngIf="isLoading">DOWNLOADING...</span>
             </button>

--- a/src/app/features/tracking/components/all-tracking/all-tracking.component.ts
+++ b/src/app/features/tracking/components/all-tracking/all-tracking.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 
 // TODO: Backend - Create Tracking Interfaces
@@ -45,21 +45,14 @@ export class AllTrackingComponent implements OnInit {
   isLoading: boolean = false;
   isMobile: boolean = false;
 
-  // Form values
-  trackingNumber: string = '';
-  referenceNumber: string = '';
-  selectedCountry: string = '';
-  tcnNumber: string = '';
-  shipDate: string = '';
-  proofNumber: string = '';
-
-  // Validation states
-  isTrackingValid: boolean = false;
-  isReferenceValid: boolean = false;
-  isTCNValid: boolean = false;
-  isProofValid: boolean = false;
+  // Reactive forms
+  trackingForm!: FormGroup;
+  referenceForm!: FormGroup;
+  tcnForm!: FormGroup;
+  proofForm!: FormGroup;
 
   constructor(
+    private fb: FormBuilder, // FormBuilder for reactive forms
     // TODO: Inject services
     // private trackingService: TrackingService,
     // private notificationService: NotificationService
@@ -68,6 +61,25 @@ export class AllTrackingComponent implements OnInit {
   ngOnInit(): void {
     this.checkDevice();
     this.initializeTracking();
+
+    // Initialize reactive forms
+    this.trackingForm = this.fb.group({
+      trackingNumber: ['', [Validators.required, Validators.pattern(/^[A-Za-z0-9]{8,}$/)]]
+    });
+
+    this.referenceForm = this.fb.group({
+      referenceNumber: ['', [Validators.required, Validators.minLength(3)]],
+      selectedCountry: ['', Validators.required]
+    });
+
+    this.tcnForm = this.fb.group({
+      tcnNumber: ['', [Validators.required, Validators.minLength(6)]],
+      shipDate: ['', Validators.required]
+    });
+
+    this.proofForm = this.fb.group({
+      proofNumber: ['', [Validators.required, Validators.minLength(8)]]
+    });
   }
 
   private checkDevice(): void {
@@ -83,22 +95,6 @@ export class AllTrackingComponent implements OnInit {
     this.activeTab = tabId;
   }
 
-  validateInput(type: string, value: string): void {
-    switch(type) {
-      case 'tracking':
-        this.isTrackingValid = value.length >= 8;
-        break;
-      case 'reference':
-        this.isReferenceValid = value.length >= 3 && this.selectedCountry !== '';
-        break;
-      case 'tcn':
-        this.isTCNValid = value.length >= 6 && this.shipDate !== '';
-        break;
-      case 'proof':
-        this.isProofValid = value.length >= 8;
-        break;
-    }
-  }
 
   async startBarcodeScanner(): Promise<void> {
     if (!this.isMobile) {
@@ -111,16 +107,16 @@ export class AllTrackingComponent implements OnInit {
       /*
       const result = await this.barcodeService.startScanning();
       if (result) {
-        this.trackingNumber = result;
-        this.validateInput('tracking', result);
+        this.trackingForm.patchValue({ trackingNumber: result });
+        this.trackingForm.get('trackingNumber')?.markAsTouched();
       }
       */
       
       // Simulation for development
       alert('Scanner de code-barres activé!\n\n(Fonctionnalité à intégrer avec l\'API caméra)');
       setTimeout(() => {
-        this.trackingNumber = 'GBX123456789';
-        this.validateInput('tracking', this.trackingNumber);
+        this.trackingForm.patchValue({ trackingNumber: 'GBX123456789' });
+        this.trackingForm.get('trackingNumber')?.markAsTouched();
       }, 2000);
     } catch (error) {
       console.error('Barcode scanning error:', error);
@@ -130,14 +126,17 @@ export class AllTrackingComponent implements OnInit {
 
   async trackPackage(event: Event): Promise<void> {
     event.preventDefault();
-    if (!this.isTrackingValid) return;
+    if (this.trackingForm.invalid) {
+      this.trackingForm.markAllAsTouched();
+      return;
+    }
 
     this.isLoading = true;
     try {
       // TODO: Implement tracking service call
       /*
       const result = await this.trackingService.track({
-        trackingNumber: this.trackingNumber,
+        trackingNumber: this.trackingForm.value.trackingNumber,
         type: 'number'
       });
       this.notificationService.success('Tracking information retrieved successfully');
@@ -145,8 +144,9 @@ export class AllTrackingComponent implements OnInit {
       */
       
       // Simulation for development
-      console.log('Tracking package:', this.trackingNumber);
-      alert(`Recherche du colis: ${this.trackingNumber}\n\n(Intégration API à venir)`);
+      const number = this.trackingForm.value.trackingNumber;
+      console.log('Tracking package:', number);
+      alert(`Recherche du colis: ${number}\n\n(Intégration API à venir)`);
     } catch (error) {
       console.error('Tracking error:', error);
       // this.notificationService.error('Failed to retrieve tracking information');
@@ -157,16 +157,20 @@ export class AllTrackingComponent implements OnInit {
 
   async trackByReference(event: Event): Promise<void> {
     event.preventDefault();
-    if (!this.isReferenceValid) return;
+    if (this.referenceForm.invalid) {
+      this.referenceForm.markAllAsTouched();
+      return;
+    }
 
     this.isLoading = true;
     try {
       // TODO: Implement reference tracking
-      console.log('Tracking by reference:', { 
-        reference: this.referenceNumber, 
-        country: this.selectedCountry 
+      const { referenceNumber, selectedCountry } = this.referenceForm.value;
+      console.log('Tracking by reference:', {
+        reference: referenceNumber,
+        country: selectedCountry
       });
-      alert(`Recherche par référence: ${this.referenceNumber}\nPays: ${this.selectedCountry}\n\n(Intégration API à venir)`);
+      alert(`Recherche par référence: ${referenceNumber}\nPays: ${selectedCountry}\n\n(Intégration API à venir)`);
     } catch (error) {
       console.error('Reference tracking error:', error);
     } finally {
@@ -176,16 +180,20 @@ export class AllTrackingComponent implements OnInit {
 
   async trackByTCN(event: Event): Promise<void> {
     event.preventDefault();
-    if (!this.isTCNValid) return;
+    if (this.tcnForm.invalid) {
+      this.tcnForm.markAllAsTouched();
+      return;
+    }
 
     this.isLoading = true;
     try {
       // TODO: Implement TCN tracking
-      console.log('Tracking by TCN:', { 
-        tcn: this.tcnNumber, 
-        shipDate: this.shipDate 
+      const { tcnNumber, shipDate } = this.tcnForm.value;
+      console.log('Tracking by TCN:', {
+        tcn: tcnNumber,
+        shipDate
       });
-      alert(`Recherche TCN: ${this.tcnNumber}\nDate: ${this.shipDate}\n\n(Intégration API à venir)`);
+      alert(`Recherche TCN: ${tcnNumber}\nDate: ${shipDate}\n\n(Intégration API à venir)`);
     } catch (error) {
       console.error('TCN tracking error:', error);
     } finally {
@@ -195,13 +203,17 @@ export class AllTrackingComponent implements OnInit {
 
   async getProofOfDelivery(event: Event): Promise<void> {
     event.preventDefault();
-    if (!this.isProofValid) return;
+    if (this.proofForm.invalid) {
+      this.proofForm.markAllAsTouched();
+      return;
+    }
 
     this.isLoading = true;
     try {
       // TODO: Implement proof of delivery download
-      console.log('Getting proof of delivery for:', this.proofNumber);
-      alert(`Téléchargement de la preuve de livraison pour: ${this.proofNumber}\n\n(Intégration API à venir)`);
+      const proof = this.proofForm.value.proofNumber;
+      console.log('Getting proof of delivery for:', proof);
+      alert(`Téléchargement de la preuve de livraison pour: ${proof}\n\n(Intégration API à venir)`);
     } catch (error) {
       console.error('Proof of delivery error:', error);
     } finally {


### PR DESCRIPTION
## Summary
- switch to reactive forms in `AllTrackingComponent`
- replace `ngModel` usage with `formControlName`
- add validators and validation messages

## Testing
- `npx ng test --watch=false` *(fails: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_684cf12e1240832e9061144738597029