### PR TITLE
Integrate reusable tracking search component

### DIFF
--- a/src/app/features/tracking/components/all-tracking/all-tracking.component.html
+++ b/src/app/features/tracking/components/all-tracking/all-tracking.component.html
@@ -50,55 +50,7 @@
       
       <!-- Track by Number -->
       <div class="tracking-panel" [class.active]="activeTab === 'tracking-number'">
-        <p class="tracking-description">
-          Enter up to 30 of your Globex tracking, door tag, or Globex Office order numbers (one per line).
-        </p>
-        
-        <form class="tracking-form" (ngSubmit)="trackPackage($event)">
-          <div class="form-group">
-            <label class="form-label" for="trackingInput">Tracking number*</label>
-            <input 
-              type="text" 
-              id="trackingInput"
-              class="form-input" 
-              placeholder="Enter tracking number"
-              [(ngModel)]="trackingNumber"
-              name="trackingNumber"
-              (input)="validateInput('tracking', trackingNumber)"
-            >
-          </div>
-
-          <!-- ===== SCAN BARCODE SECTION ===== -->
-          <div class="scan-section">
-            <div class="scan-icon">
-              <i class="fas fa-qrcode"></i>
-            </div>
-            <h3 class="scan-title">Scan Barcode</h3>
-            <p class="scan-description">
-              Use your mobile device to scan the barcode on your shipping label
-            </p>
-            <button 
-              type="button" 
-              class="scan-btn" 
-              (click)="startBarcodeScanner()"
-              [disabled]="isLoading">
-              <i class="fas fa-camera"></i> Scan Barcode
-            </button>
-          </div>
-
-          <a href="#" class="need-help">NEED HELP?</a>
-          
-          <div style="text-align: center;">
-            <button 
-              type="submit" 
-              class="track-btn" 
-              [class.enabled]="isTrackingValid"
-              [disabled]="!isTrackingValid || isLoading">
-              <span *ngIf="!isLoading">TRACK</span>
-              <span *ngIf="isLoading">TRACKING...</span>
-            </button>
-          </div>
-        </form>
+        <app-tracking-search (search)="trackPackage($event)"></app-tracking-search>
       </div>
 
       <!-- Track by Reference -->

--- a/src/app/features/tracking/components/all-tracking/all-tracking.component.ts
+++ b/src/app/features/tracking/components/all-tracking/all-tracking.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
+import { TrackingSearchComponent } from '../tracking-search/tracking-search.component';
 
 // TODO: Backend - Create Tracking Interfaces
 interface TrackingRequest {
@@ -35,7 +36,8 @@ interface TrackingEvent {
     CommonModule,
     FormsModule,
     ReactiveFormsModule,
-    RouterModule
+    RouterModule,
+    TrackingSearchComponent
   ],
   templateUrl: './all-tracking.component.html',
   styleUrls: ['./all-tracking.component.scss']
@@ -128,25 +130,33 @@ export class AllTrackingComponent implements OnInit {
     }
   }
 
-  async trackPackage(event: Event): Promise<void> {
-    event.preventDefault();
-    if (!this.isTrackingValid) return;
+  async trackPackage(eventOrNumber: Event | string): Promise<void> {
+    let value: string;
+    if (typeof eventOrNumber === 'string') {
+      value = eventOrNumber;
+      this.trackingNumber = value;
+    } else {
+      eventOrNumber.preventDefault();
+      value = this.trackingNumber;
+    }
+
+    if (!value || value.length < 8) return;
 
     this.isLoading = true;
     try {
       // TODO: Implement tracking service call
       /*
       const result = await this.trackingService.track({
-        trackingNumber: this.trackingNumber,
+        trackingNumber: value,
         type: 'number'
       });
       this.notificationService.success('Tracking information retrieved successfully');
       // Navigate to results page or show results
       */
-      
+
       // Simulation for development
-      console.log('Tracking package:', this.trackingNumber);
-      alert(`Recherche du colis: ${this.trackingNumber}\n\n(Intégration API à venir)`);
+      console.log('Tracking package:', value);
+      alert(`Recherche du colis: ${value}\n\n(Intégration API à venir)`);
     } catch (error) {
       console.error('Tracking error:', error);
       // this.notificationService.error('Failed to retrieve tracking information');

--- a/src/app/features/tracking/components/tracking-search/tracking-search.component.ts
+++ b/src/app/features/tracking/components/tracking-search/tracking-search.component.ts
@@ -1,7 +1,11 @@
 import { Component, OnInit, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 
 @Component({
   selector: 'app-tracking-search',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
   templateUrl: './tracking-search.component.html',
   styleUrls: ['./tracking-search.component.scss']
 })


### PR DESCRIPTION
## Summary
- make `TrackingSearchComponent` standalone for reuse
- embed the component in the tracking-number tab
- forward emitted search values to existing tracking logic

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf1365658832eacf6aee60762ca63