### PR TITLE
Add tracking component tests

### DIFF
--- a/src/app/features/tracking/components/all-tracking/all-tracking.component.spec.ts
+++ b/src/app/features/tracking/components/all-tracking/all-tracking.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 
 import { AllTrackingComponent } from './all-tracking.component';
 
@@ -19,5 +19,47 @@ describe('AllTrackingComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should validate tracking number', () => {
+    component.validateInput('tracking', '123');
+    expect(component.isTrackingValid).toBeFalse();
+    component.validateInput('tracking', '12345678');
+    expect(component.isTrackingValid).toBeTrue();
+  });
+
+  it('should validate reference with country', () => {
+    component.selectedCountry = 'MA';
+    component.validateInput('reference', 'ab');
+    expect(component.isReferenceValid).toBeFalse();
+    component.validateInput('reference', 'abc');
+    expect(component.isReferenceValid).toBeTrue();
+  });
+
+  it('should alert when scanner used on desktop', () => {
+    spyOn(window, 'alert');
+    component.isMobile = false;
+    component.startBarcodeScanner();
+    expect(window.alert).toHaveBeenCalledWith('Le scanner de code-barres est disponible uniquement sur mobile.');
+  });
+
+  it('should scan barcode on mobile', fakeAsync(() => {
+    spyOn(window, 'alert');
+    component.isMobile = true;
+    component.startBarcodeScanner();
+    expect(window.alert).toHaveBeenCalledWith("Scanner de code-barres activé!\n\n(Fonctionnalité à intégrer avec l'API caméra)");
+    tick(2000);
+    expect(component.trackingNumber).toBe('GBX123456789');
+    expect(component.isTrackingValid).toBeTrue();
+  }));
+
+  it('should handle scanner errors', () => {
+    spyOn(window, 'alert');
+    component.isMobile = true;
+    const original = window.setTimeout;
+    spyOn(window, 'setTimeout').and.callFake(() => { throw new Error('fail'); });
+    component.startBarcodeScanner();
+    expect(window.alert).toHaveBeenCalledWith('Erreur lors du scan du code-barres.');
+    (window.setTimeout as any) = original;
   });
 });

--- a/src/app/features/tracking/components/tracking-result/tracking-result.component.spec.ts
+++ b/src/app/features/tracking/components/tracking-result/tracking-result.component.spec.ts
@@ -1,0 +1,64 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { TrackingResultComponent } from './tracking-result.component';
+import { TrackingService } from '../../services/tracking.service';
+import { TrackingData } from '../../models/tracking-data.model';
+
+describe('TrackingResultComponent', () => {
+  let component: TrackingResultComponent;
+  let fixture: ComponentFixture<TrackingResultComponent>;
+  let trackingService: jasmine.SpyObj<TrackingService>;
+
+  const mockData: TrackingData = {
+    id: '1',
+    trackingNumber: 'GBX123456789',
+    status: 'IN-TRANSIT',
+    statusDetails: '',
+    statusDetail: '',
+    estimatedDeliveryDate: '2025-01-01',
+    estimatedDelivery: { date: '2025-01-01', timeframe: 'AM' },
+    shipDate: '2024-12-31',
+    shippingDate: '2024-12-31',
+    service: 'Express',
+    sender: { name: 'A', address: '', location: '' },
+    recipient: { name: 'B', address: '', location: '' },
+    currentLocation: { address: '' },
+    packageInfo: { weight: '', dimensions: '', pieces: '', insurance: '', items: 1, reference: '' },
+    history: []
+  };
+
+  beforeEach(async () => {
+    const spy = jasmine.createSpyObj('TrackingService', ['getTrackingData']);
+    await TestBed.configureTestingModule({
+      imports: [TrackingResultComponent],
+      providers: [{ provide: TrackingService, useValue: spy }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TrackingResultComponent);
+    component = fixture.componentInstance;
+    trackingService = TestBed.inject(TrackingService) as jasmine.SpyObj<TrackingService>;
+  });
+
+  it('should load tracking data successfully', fakeAsync(() => {
+    trackingService.getTrackingData.and.returnValue(of(mockData));
+    component.trackingNumber = 'GBX123456789';
+    component.loadTrackingData();
+    tick();
+
+    expect(trackingService.getTrackingData).toHaveBeenCalledWith('GBX123456789');
+    expect(component.trackingData).toEqual(mockData);
+    expect(component.error).toBeFalse();
+    expect(component.isLoading).toBeFalse();
+  }));
+
+  it('should handle service error', fakeAsync(() => {
+    trackingService.getTrackingData.and.returnValue(throwError(() => new Error('fail')));
+    component.trackingNumber = 'BAD';
+    component.loadTrackingData();
+    tick();
+
+    expect(component.error).toBeTrue();
+    expect(component.trackingData).toBeNull();
+    expect(component.errorMessage).toBe('Numéro de suivi invalide ou introuvable');
+  }));
+});


### PR DESCRIPTION
## Summary
- test `validateInput` for tracking and reference inputs
- test barcode scanning behavior and error handling
- add unit tests for tracking result component

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684cf1384744832eb1b0e9697cc49748