### PR TITLE
Connect tracking service

### DIFF
--- a/src/app/features/tracking/components/all-tracking/all-tracking.component.ts
+++ b/src/app/features/tracking/components/all-tracking/all-tracking.component.ts
@@ -1,7 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { RouterModule } from '@angular/router';
+import { RouterModule, Router } from '@angular/router';
+import { TrackingService } from '../../services/tracking.service';
+import { NotificationService } from '../../../../shared/services/notification.service';
 
 // TODO: Backend - Create Tracking Interfaces
 interface TrackingRequest {
@@ -60,9 +62,9 @@ export class AllTrackingComponent implements OnInit {
   isProofValid: boolean = false;
 
   constructor(
-    // TODO: Inject services
-    // private trackingService: TrackingService,
-    // private notificationService: NotificationService
+    private trackingService: TrackingService,
+    private notificationService: NotificationService,
+    private router: Router
   ) {}
 
   ngOnInit(): void {
@@ -133,26 +135,23 @@ export class AllTrackingComponent implements OnInit {
     if (!this.isTrackingValid) return;
 
     this.isLoading = true;
-    try {
-      // TODO: Implement tracking service call
-      /*
-      const result = await this.trackingService.track({
-        trackingNumber: this.trackingNumber,
-        type: 'number'
-      });
-      this.notificationService.success('Tracking information retrieved successfully');
-      // Navigate to results page or show results
-      */
-      
-      // Simulation for development
-      console.log('Tracking package:', this.trackingNumber);
-      alert(`Recherche du colis: ${this.trackingNumber}\n\n(Intégration API à venir)`);
-    } catch (error) {
-      console.error('Tracking error:', error);
-      // this.notificationService.error('Failed to retrieve tracking information');
-    } finally {
-      this.isLoading = false;
-    }
+    this.trackingService.getTrackingData(this.trackingNumber).subscribe({
+      next: (data) => {
+        this.notificationService.success('Informations de suivi récupérées');
+        this.router.navigate(['./result'], {
+          queryParams: { number: this.trackingNumber },
+          state: { data }
+        });
+        this.isLoading = false;
+      },
+      error: (err: Error) => {
+        console.error('Tracking error:', err);
+        this.notificationService.error(
+          err.message || 'Erreur lors de la récupération des informations de suivi'
+        );
+        this.isLoading = false;
+      }
+    });
   }
 
   async trackByReference(event: Event): Promise<void> {

--- a/src/app/features/tracking/components/tracking-result/tracking-result.component.ts
+++ b/src/app/features/tracking/components/tracking-result/tracking-result.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, AfterViewInit, Input, Output, EventEmitter } from '@angular/core';
-import { ActivatedRoute, RouterLink } from '@angular/router';
+import { ActivatedRoute, RouterLink, Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgClass, NgIf, NgFor, NgStyle } from '@angular/common';
@@ -108,16 +108,26 @@ export class TrackingResultComponent implements OnInit, AfterViewInit {
 
   constructor(
     private route: ActivatedRoute,
-    private trackingService: TrackingService
+    private trackingService: TrackingService,
+    private router: Router
   ) { }
 
   ngOnInit(): void {
-    this.route.queryParams.subscribe(params => {
-      if (params['number']) {
-        this.trackingNumber = params['number'];
-        this.loadTrackingData();
-      }
-    });
+    const nav = this.router.getCurrentNavigation();
+    const stateData = nav?.extras?.state as { data?: TrackingData } | undefined;
+    if (stateData?.data) {
+      this.trackingData = stateData.data;
+      this.trackingNumber = stateData.data.trackingNumber;
+      this.isLoading = false;
+      this.loading = false;
+    } else {
+      this.route.queryParams.subscribe(params => {
+        if (params['number']) {
+          this.trackingNumber = params['number'];
+          this.loadTrackingData();
+        }
+      });
+    }
     
     // Close dropdowns when clicking outside
     document.addEventListener('click', (event: MouseEvent) => {

--- a/src/app/features/tracking/services/tracking.service.ts
+++ b/src/app/features/tracking/services/tracking.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../../../environments/environment';
 import { Observable, of, throwError } from 'rxjs';
 import { catchError, delay, map } from 'rxjs/operators';
 import { TrackingData } from '../models/tracking-data.model';
@@ -24,7 +25,7 @@ export interface PackageInfo {
   providedIn: 'root'
 })
 export class TrackingService {
-  private apiUrl = 'http://localhost:8000/api';
+  private apiUrl = environment.apiUrl;
 
   constructor(private http: HttpClient) { }
 


### PR DESCRIPTION
## Summary
- inject tracking and notification services
- call tracking service instead of alert-based simulation
- pass retrieved data via navigation state
- load state data in the tracking result component
- use environment `apiUrl` in TrackingService

## Testing
- `npm test` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_684cf142dab8832ebb7bc580e0a11dfd