### PR TITLE
Add barcode scanning with ngx-scanner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@fortawesome/free-regular-svg-icons": "^6.4.0",
         "@fortawesome/free-solid-svg-icons": "^6.4.0",
         "@types/leaflet": "^1.9.18",
+        "@zxing/ngx-scanner": "^19.0.0",
         "file-saver": "^2.0.5",
         "leaflet": "^1.9.4",
         "rxjs": "~7.8.0",
@@ -4442,6 +4443,60 @@
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/@zxing/browser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@zxing/browser/-/browser-0.1.5.tgz",
+      "integrity": "sha512-4Lmrn/il4+UNb87Gk8h1iWnhj39TASEHpd91CwwSJtY5u+wa0iH9qS0wNLAWbNVYXR66WmT5uiMhZ7oVTrKfxw==",
+      "license": "MIT",
+      "peer": true,
+      "optionalDependencies": {
+        "@zxing/text-encoding": "^0.9.0"
+      },
+      "peerDependencies": {
+        "@zxing/library": "^0.21.0"
+      }
+    },
+    "node_modules/@zxing/library": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.21.3.tgz",
+      "integrity": "sha512-hZHqFe2JyH/ZxviJZosZjV+2s6EDSY0O24R+FQmlWZBZXP9IqMo7S3nb3+2LBWxodJQkSurdQGnqE7KXqrYgow==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ts-custom-error": "^3.2.1"
+      },
+      "engines": {
+        "node": ">= 10.4.0"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "~0.9.0"
+      }
+    },
+    "node_modules/@zxing/ngx-scanner": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@zxing/ngx-scanner/-/ngx-scanner-19.0.0.tgz",
+      "integrity": "sha512-2V0617jKVTjZ3ekEf5uMjfjOE0jjazt2GT/zvfGt68ZxjDMYyGMuKj6p+0KP+pjnxiXHE6NwWaVUWfW43uKtvA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^11.2.11 || ^12.0.4 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@angular/core": "^11.2.11 || ^12.0.4 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@angular/forms": "^11.2.11 || ^12.0.4 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@zxing/browser": "^0.1.4",
+        "@zxing/library": "^0.21.0",
+        "rxjs": "^6.6.3 || ^7.0.0"
+      }
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "license": "(Unlicense OR Apache-2.0)",
+      "optional": true,
+      "peer": true
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -13124,6 +13179,16 @@
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-custom-error": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.4.0",
     "@fortawesome/free-solid-svg-icons": "^6.4.0",
     "@types/leaflet": "^1.9.18",
+    "@zxing/ngx-scanner": "^19.0.0",
     "file-saver": "^2.0.5",
     "leaflet": "^1.9.4",
     "rxjs": "~7.8.0",

--- a/src/app/features/tracking/components/all-tracking/all-tracking.component.html
+++ b/src/app/features/tracking/components/all-tracking/all-tracking.component.html
@@ -9,6 +9,7 @@
   </div>
 </section>
 
+
 <!-- ===== MAIN CONTENT ===== -->
 <main class="main-content">
   <div class="container">
@@ -297,3 +298,14 @@
     </div>
   </div>
 </section>
+
+<!-- Barcode scanner modal -->
+<div class="scanner-modal" *ngIf="showScanner">
+  <div class="scanner-container">
+    <zxing-scanner
+      [enable]="showScanner"
+      (scanSuccess)="onCodeResult($event)"></zxing-scanner>
+    <button type="button" class="close-btn" (click)="closeScanner()">Close</button>
+  </div>
+</div>
+

--- a/src/app/features/tracking/components/all-tracking/all-tracking.component.scss
+++ b/src/app/features/tracking/components/all-tracking/all-tracking.component.scss
@@ -439,3 +439,35 @@ body {
     padding: 60px 0;
   }
 }
+
+// Barcode scanner modal styles
+.scanner-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+
+  .scanner-container {
+    width: 90%;
+    max-width: 400px;
+    background: var(--white);
+    padding: 20px;
+    border-radius: 8px;
+  }
+
+  .close-btn {
+    margin-top: 10px;
+    background: var(--primary-orange);
+    color: var(--white);
+    border: none;
+    padding: 10px 20px;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+}

--- a/src/app/features/tracking/components/all-tracking/all-tracking.component.ts
+++ b/src/app/features/tracking/components/all-tracking/all-tracking.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
+import { ZXingScannerModule } from '@zxing/ngx-scanner';
 
 // TODO: Backend - Create Tracking Interfaces
 interface TrackingRequest {
@@ -35,7 +36,8 @@ interface TrackingEvent {
     CommonModule,
     FormsModule,
     ReactiveFormsModule,
-    RouterModule
+    RouterModule,
+    ZXingScannerModule
   ],
   templateUrl: './all-tracking.component.html',
   styleUrls: ['./all-tracking.component.scss']
@@ -44,6 +46,7 @@ export class AllTrackingComponent implements OnInit {
   activeTab: string = 'tracking-number';
   isLoading: boolean = false;
   isMobile: boolean = false;
+  showScanner: boolean = false;
 
   // Form values
   trackingNumber: string = '';
@@ -105,27 +108,19 @@ export class AllTrackingComponent implements OnInit {
       alert('Le scanner de code-barres est disponible uniquement sur mobile.');
       return;
     }
+    this.showScanner = true;
+  }
 
-    try {
-      // TODO: Implement barcode scanning
-      /*
-      const result = await this.barcodeService.startScanning();
-      if (result) {
-        this.trackingNumber = result;
-        this.validateInput('tracking', result);
-      }
-      */
-      
-      // Simulation for development
-      alert('Scanner de code-barres activé!\n\n(Fonctionnalité à intégrer avec l\'API caméra)');
-      setTimeout(() => {
-        this.trackingNumber = 'GBX123456789';
-        this.validateInput('tracking', this.trackingNumber);
-      }, 2000);
-    } catch (error) {
-      console.error('Barcode scanning error:', error);
-      alert('Erreur lors du scan du code-barres.');
+  onCodeResult(result: string): void {
+    if (result) {
+      this.trackingNumber = result;
+      this.validateInput('tracking', result);
     }
+    this.showScanner = false;
+  }
+
+  closeScanner(): void {
+    this.showScanner = false;
   }
 
   async trackPackage(event: Event): Promise<void> {


### PR DESCRIPTION
## Summary
- integrate `@zxing/ngx-scanner` package
- use `ZXingScannerModule` in tracking feature
- implement real barcode scanner logic
- show scanner modal on mobile
- style scanner modal

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_684cf144bf20832eab811ab97fca0640