### PR TITLE
Fix trailing text in tracking modules

### DIFF
--- a/src/app/features/tracking/tracking-routing.module.ts
+++ b/src/app/features/tracking/tracking-routing.module.ts
@@ -22,4 +22,4 @@ const routes: Routes = [
   imports: [RouterModule.forChild(routes)],
   exports: [RouterModule]
 })
-export class TrackingRoutingModule { } 
+export class TrackingRoutingModule { }

--- a/src/app/features/tracking/tracking.module.ts
+++ b/src/app/features/tracking/tracking.module.ts
@@ -12,4 +12,4 @@ import { TrackingRoutingModule } from './tracking-routing.module';
     TrackingRoutingModule
   ]
 })
-export class TrackingModule { } 
+export class TrackingModule { }


### PR DESCRIPTION
## Summary
- trim trailing prompt text from `tracking.module.ts`
- trim trailing prompt text from `tracking-routing.module.ts`

## Testing
- `npm test --silent -- --watch=false --browsers=ChromeHeadless` *(fails: Error: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_684cf147e000832e8ebdf78ecd6c7a2e