### PR TITLE
Use environment URL in TrackingService

### DIFF
--- a/src/app/features/tracking/services/tracking.service.ts
+++ b/src/app/features/tracking/services/tracking.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { Observable, of, throwError } from 'rxjs';
 import { catchError, delay, map } from 'rxjs/operators';
 import { TrackingData } from '../models/tracking-data.model';
+import { environment } from '../../../../environments/environment';
 
 export interface HistoryItem {
   status: string;
@@ -24,7 +25,7 @@ export interface PackageInfo {
   providedIn: 'root'
 })
 export class TrackingService {
-  private apiUrl = 'http://localhost:8000/api';
+  private apiUrl = environment.apiUrl;
 
   constructor(private http: HttpClient) { }
 


### PR DESCRIPTION
## Summary
- inject environment configuration in `TrackingService`
- use `environment.apiUrl` for API calls

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf14bb050832ea7caf808109a9859