### PR TITLE
Improve all-tracking tests

### DIFF
--- a/src/app/features/tracking/components/all-tracking/all-tracking.component.spec.ts
+++ b/src/app/features/tracking/components/all-tracking/all-tracking.component.spec.ts
@@ -1,24 +1,70 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+import { TrackingService } from '../../services/tracking.service';
+import { NotificationService } from '../../../../shared/services/notification.service';
 
 import { AllTrackingComponent } from './all-tracking.component';
 
 describe('AllTrackingComponent', () => {
   let component: AllTrackingComponent;
   let fixture: ComponentFixture<AllTrackingComponent>;
+  let trackingService: jasmine.SpyObj<TrackingService>;
+  let notificationService: jasmine.SpyObj<NotificationService>;
 
   beforeEach(async () => {
+    const trackingSpy = jasmine.createSpyObj('TrackingService', ['getTrackingData']);
+    const notifSpy = jasmine.createSpyObj('NotificationService', ['success', 'error']);
+
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule, AllTrackingComponent]
-    })
-    .compileComponents();
-    
+      imports: [RouterTestingModule, AllTrackingComponent],
+      providers: [
+        { provide: TrackingService, useValue: trackingSpy },
+        { provide: NotificationService, useValue: notifSpy }
+      ]
+    }).compileComponents();
+
     fixture = TestBed.createComponent(AllTrackingComponent);
     component = fixture.componentInstance;
+    trackingService = TestBed.inject(TrackingService) as jasmine.SpyObj<TrackingService>;
+    notificationService = TestBed.inject(NotificationService) as jasmine.SpyObj<NotificationService>;
+    trackingService.getTrackingData.and.returnValue(of({}));
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should disable track button when tracking number is invalid', () => {
+    component.trackingNumber = '123';
+    component.validateInput('tracking', component.trackingNumber);
+    fixture.detectChanges();
+
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('.tracking-panel.active button.track-btn');
+    expect(component.isTrackingValid).toBeFalse();
+    expect(button.disabled).toBeTrue();
+  });
+
+  it('should enable track button when tracking number is valid', () => {
+    component.trackingNumber = 'GBX123456';
+    component.validateInput('tracking', component.trackingNumber);
+    fixture.detectChanges();
+
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('.tracking-panel.active button.track-btn');
+    expect(component.isTrackingValid).toBeTrue();
+    expect(button.disabled).toBeFalse();
+  });
+
+  it('should call services on trackPackage', fakeAsync(() => {
+    component.trackingNumber = 'GBX123456';
+    component.validateInput('tracking', component.trackingNumber);
+    fixture.detectChanges();
+
+    component.trackPackage(new Event('submit'));
+    tick();
+
+    expect(trackingService.getTrackingData).toHaveBeenCalledWith('GBX123456');
+    expect(notificationService.success).toHaveBeenCalled();
+  }));
 });

--- a/src/app/features/tracking/components/all-tracking/all-tracking.component.ts
+++ b/src/app/features/tracking/components/all-tracking/all-tracking.component.ts
@@ -2,6 +2,9 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule, Router } from '@angular/router';
+import { firstValueFrom } from 'rxjs';
+import { TrackingService } from '../../services/tracking.service';
+import { NotificationService } from '../../../../shared/services/notification.service';
 
 // TODO: Backend - Create Tracking Interfaces
 interface TrackingRequest {
@@ -61,9 +64,8 @@ export class AllTrackingComponent implements OnInit {
 
   constructor(
     private router: Router,
-    // TODO: Inject services
-    // private trackingService: TrackingService,
-    // private notificationService: NotificationService
+    private trackingService: TrackingService,
+    private notificationService: NotificationService
   ) {}
 
   ngOnInit(): void {
@@ -135,28 +137,17 @@ export class AllTrackingComponent implements OnInit {
 
     this.isLoading = true;
     try {
-      // TODO: Implement tracking service call
-      /*
-      const result = await this.trackingService.track({
-        trackingNumber: this.trackingNumber,
-        type: 'number'
-      });
-      this.notificationService.success('Tracking information retrieved successfully');
-      // Navigate to results page or show results
-      */
-      
-      // Simulation for development
-      console.log('Tracking package:', this.trackingNumber);
-      alert(`Recherche du colis: ${this.trackingNumber}\n\n(Intégration API à venir)`);
+      await firstValueFrom(this.trackingService.getTrackingData(this.trackingNumber));
+      this.notificationService.success('Tracking information retrieved successfully', '');
       this.router.navigate(['/tracking/result'], {
         queryParams: {
           number: this.trackingNumber,
           type: 'number'
         }
       });
-    } catch (error) {
+    } catch (error: any) {
       console.error('Tracking error:', error);
-      // this.notificationService.error('Failed to retrieve tracking information');
+      this.notificationService.error('Failed to retrieve tracking information', error.message);
     } finally {
       this.isLoading = false;
     }


### PR DESCRIPTION
## Summary
- inject tracking and notification services in AllTrackingComponent
- call tracking service and notify inside trackPackage
- extend all-tracking.component.spec to cover validation rules and service calls

## Testing
- `npx ng test --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf15a6b38832eba3ebe900e360b8e