### PR TITLE
Fix NotificationService usage

### DIFF
--- a/src/app/pages/help/help.component.ts
+++ b/src/app/pages/help/help.component.ts
@@ -104,11 +104,11 @@ export class HelpComponent implements OnInit {
 
   quickTrack() {
     if (!this.trackingNumber) {
-      this.notificationService.show('Please enter a tracking number', 'warning');
+      this.notificationService.warning('Warning', 'Please enter a tracking number');
       return;
     }
 
-    this.notificationService.show(`Tracking package ${this.trackingNumber}...`, 'info');
+    this.notificationService.info('Tracking', `Tracking package ${this.trackingNumber}...`);
     
     setTimeout(() => {
       this.router.navigate(['/tracking'], {

--- a/src/app/pages/help/tracking-advice/tracking-advice.component.ts
+++ b/src/app/pages/help/tracking-advice/tracking-advice.component.ts
@@ -13,26 +13,26 @@ export class TrackingAdviceComponent {
   constructor(private notificationService: NotificationService) {}
 
   openTrackingGuide() {
-    this.notificationService.show('Opening comprehensive tracking guide...', 'info');
+    this.notificationService.info('Tracking', 'Opening comprehensive tracking guide...');
   }
 
   openStatusGuide() {
-    this.notificationService.show('Opening status definitions guide...', 'info');
+    this.notificationService.info('Tracking', 'Opening status definitions guide...');
   }
 
   openTroubleshooting() {
-    this.notificationService.show('Opening troubleshooting wizard...', 'info');
+    this.notificationService.info('Tracking', 'Opening troubleshooting wizard...');
   }
 
   setupNotifications() {
-    this.notificationService.show('Opening notification preferences...', 'info');
+    this.notificationService.info('Tracking', 'Opening notification preferences...');
   }
 
   viewDeliveryTimes() {
-    this.notificationService.show('Opening delivery time calculator...', 'info');
+    this.notificationService.info('Tracking', 'Opening delivery time calculator...');
   }
 
   learnSecurity() {
-    this.notificationService.show('Opening security information...', 'info');
+    this.notificationService.info('Tracking', 'Opening security information...');
   }
 } 


### PR DESCRIPTION
## Summary
- use explicit `info`/`warning` notification helpers

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf37b601c832e9bfb070dbac1541e