### PR TITLE
Refactor help tabs to use router

### DIFF
--- a/src/app/pages/help/help.component.html
+++ b/src/app/pages/help/help.component.html
@@ -53,50 +53,58 @@
 
         <!-- ===== NAVIGATION TABS ===== -->
         <nav class="nav-tabs animate-fade-in" role="tablist" aria-label="Help categories">
-            <button 
-                class="nav-tab" 
-                [class.active]="currentTab === 'tracking-advice'"
-                role="tab" 
-                [attr.aria-selected]="currentTab === 'tracking-advice'"
-                aria-controls="tracking-advice" 
-                id="advice-tab" 
-                (click)="switchTab('tracking-advice')"
+            <button
+                class="nav-tab"
+                routerLink="./advice"
+                routerLinkActive="active"
+                [routerLinkActiveOptions]="{ exact: true }"
+                #adviceRla="routerLinkActive"
+                role="tab"
+                [attr.aria-selected]="adviceRla.isActive"
+                aria-controls="tracking-advice"
+                id="advice-tab"
             >
                 <i class="fas fa-lightbulb" aria-hidden="true"></i>
                 Tracking Advice
             </button>
-            <button 
-                class="nav-tab" 
-                [class.active]="currentTab === 'tracking-tools'"
-                role="tab" 
-                [attr.aria-selected]="currentTab === 'tracking-tools'"
-                aria-controls="tracking-tools" 
-                id="tools-tab" 
-                (click)="switchTab('tracking-tools')"
+            <button
+                class="nav-tab"
+                routerLink="./tools"
+                routerLinkActive="active"
+                [routerLinkActiveOptions]="{ exact: true }"
+                #toolsRla="routerLinkActive"
+                role="tab"
+                [attr.aria-selected]="toolsRla.isActive"
+                aria-controls="tracking-tools"
+                id="tools-tab"
             >
                 <i class="fas fa-tools" aria-hidden="true"></i>
                 Tracking Tools
             </button>
-            <button 
-                class="nav-tab" 
-                [class.active]="currentTab === 'faqs'"
-                role="tab" 
-                [attr.aria-selected]="currentTab === 'faqs'"
-                aria-controls="faqs" 
-                id="faqs-tab" 
-                (click)="switchTab('faqs')"
+            <button
+                class="nav-tab"
+                routerLink="./faq"
+                routerLinkActive="active"
+                [routerLinkActiveOptions]="{ exact: true }"
+                #faqRla="routerLinkActive"
+                role="tab"
+                [attr.aria-selected]="faqRla.isActive"
+                aria-controls="faqs"
+                id="faqs-tab"
             >
                 <i class="fas fa-question-circle" aria-hidden="true"></i>
                 FAQs
             </button>
-            <button 
-                class="nav-tab" 
-                [class.active]="currentTab === 'contact-us'"
-                role="tab" 
-                [attr.aria-selected]="currentTab === 'contact-us'"
-                aria-controls="contact-us" 
-                id="contact-tab" 
-                (click)="switchTab('contact-us')"
+            <button
+                class="nav-tab"
+                routerLink="./contact"
+                routerLinkActive="active"
+                [routerLinkActiveOptions]="{ exact: true }"
+                #contactRla="routerLinkActive"
+                role="tab"
+                [attr.aria-selected]="contactRla.isActive"
+                aria-controls="contact-us"
+                id="contact-tab"
             >
                 <i class="fas fa-headset" aria-hidden="true"></i>
                 Contact Us
@@ -104,11 +112,6 @@
         </nav>
 
         <!-- ===== TAB CONTENT ===== -->
-        <div [ngSwitch]="currentTab">
-            <app-tracking-advice *ngSwitchCase="'tracking-advice'" class="tab-content active"></app-tracking-advice>
-            <app-tracking-tools *ngSwitchCase="'tracking-tools'" class="tab-content active"></app-tracking-tools>
-            <app-faqs *ngSwitchCase="'faqs'" class="tab-content active"></app-faqs>
-            <app-contact-us *ngSwitchCase="'contact-us'" class="tab-content active"></app-contact-us>
-        </div>
+        <router-outlet></router-outlet>
     </div>
 </main> 

--- a/src/app/pages/help/help.component.ts
+++ b/src/app/pages/help/help.component.ts
@@ -1,15 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
-import { Router, ActivatedRoute, NavigationEnd } from '@angular/router';
-import { filter } from 'rxjs/operators';
+import { Router } from '@angular/router';
 import { NotificationService } from '../../shared/services/notification.service';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
-import { TrackingAdviceComponent } from './tracking-advice/tracking-advice.component';
-import { TrackingToolsComponent } from './tracking-tools/tracking-tools.component';
-import { FaqsComponent } from './faqs/faqs.component';
-import { ContactUsComponent } from './contact-us/contact-us.component';
 
 @Component({
   selector: 'app-help',
@@ -17,78 +12,25 @@ import { ContactUsComponent } from './contact-us/contact-us.component';
   imports: [
     CommonModule,
     FormsModule,
-    RouterModule,
-    TrackingAdviceComponent,
-    TrackingToolsComponent,
-    FaqsComponent,
-    ContactUsComponent
+    RouterModule
   ],
   templateUrl: './help.component.html',
   styleUrls: ['./help.component.scss']
 })
 export class HelpComponent implements OnInit {
-  currentTab: string = 'tracking-advice';
   trackingNumber: string = '';
 
   constructor(
     private titleService: Title,
     private router: Router,
-    private route: ActivatedRoute,
     private notificationService: NotificationService
-  ) {
-    // Subscribe to route changes to handle fragment navigation
-    this.router.events.pipe(
-      filter(event => event instanceof NavigationEnd)
-    ).subscribe(() => {
-      const fragment = this.route.snapshot.fragment;
-      if (fragment) {
-        this.handleFragmentNavigation(fragment);
-      }
-    });
-  }
+  ) {}
 
   ngOnInit() {
     this.titleService.setTitle('Tracking Help & Support - Globex Logistics');
     this.initializeAccessibility();
-    
-    // Handle initial fragment if present
-    const fragment = this.route.snapshot.fragment;
-    if (fragment) {
-      this.handleFragmentNavigation(fragment);
-    }
   }
 
-  private handleFragmentNavigation(fragment: string) {
-    switch (fragment) {
-      case 'advice':
-        this.currentTab = 'tracking-advice';
-        break;
-      case 'tools':
-        this.currentTab = 'tracking-tools';
-        break;
-      case 'faq':
-        this.currentTab = 'faqs';
-        break;
-      case 'contact':
-        this.currentTab = 'contact-us';
-        break;
-    }
-  }
-
-  switchTab(tab: string) {
-    this.currentTab = tab;
-    // Update URL fragment without triggering a navigation
-    const fragment = tab === 'tracking-advice' ? 'advice' :
-                    tab === 'tracking-tools' ? 'tools' :
-                    tab === 'faqs' ? 'faq' :
-                    tab === 'contact-us' ? 'contact' : '';
-    
-    this.router.navigate([], {
-      fragment,
-      relativeTo: this.route,
-      replaceUrl: true
-    });
-  }
 
   private initializeAccessibility() {
     // Add ARIA labels to interactive elements


### PR DESCRIPTION
## Summary
- replace tab switch logic with Angular router outlet
- use routerLink navigation for help tab buttons

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf37cd080832ea500769e43fa2efa