### PR TITLE
Add reusable QuickTrack component

### DIFF
--- a/src/app/pages/help/help.component.html
+++ b/src/app/pages/help/help.component.html
@@ -1,114 +1,124 @@
 <!-- ===== BREADCRUMB ===== -->
 <nav class="breadcrumb" aria-label="Breadcrumb">
-    <div class="container">
-        <ol class="breadcrumb__list">
-            <li class="breadcrumb__item">
-                <a routerLink="/" class="breadcrumb__link">Home</a>
-            </li>
-            <li class="breadcrumb__item">
-                <span class="breadcrumb__separator" aria-hidden="true">/</span>
-                <a routerLink="/help" class="breadcrumb__link">Help & Support</a>
-            </li>
-            <li class="breadcrumb__item">
-                <span class="breadcrumb__separator" aria-hidden="true">/</span>
-                <span class="breadcrumb__current" aria-current="page">Tracking Help</span>
-            </li>
-        </ol>
-    </div>
+  <div class="container">
+    <ol class="breadcrumb__list">
+      <li class="breadcrumb__item">
+        <a routerLink="/" class="breadcrumb__link">Home</a>
+      </li>
+      <li class="breadcrumb__item">
+        <span class="breadcrumb__separator" aria-hidden="true">/</span>
+        <a routerLink="/help" class="breadcrumb__link">Help & Support</a>
+      </li>
+      <li class="breadcrumb__item">
+        <span class="breadcrumb__separator" aria-hidden="true">/</span>
+        <span class="breadcrumb__current" aria-current="page"
+          >Tracking Help</span
+        >
+      </li>
+    </ol>
+  </div>
 </nav>
 
 <!-- ===== MAIN CONTENT ===== -->
 <main class="main" role="main">
-    <div class="container">
-        <!-- ===== PAGE HERO ===== -->
-        <section class="page-hero animate-fade-in" aria-labelledby="hero-title">
-            <h1 id="hero-title" class="page-hero__title">Tracking Help Center</h1>
-            <p class="page-hero__subtitle">Get help with tracking your packages, understanding delivery status, and resolving tracking issues</p>
-        </section>
+  <div class="container">
+    <!-- ===== PAGE HERO ===== -->
+    <section class="page-hero animate-fade-in" aria-labelledby="hero-title">
+      <h1 id="hero-title" class="page-hero__title">Tracking Help Center</h1>
+      <p class="page-hero__subtitle">
+        Get help with tracking your packages, understanding delivery status, and
+        resolving tracking issues
+      </p>
+    </section>
 
-        <!-- ===== QUICK SEARCH ===== -->
-        <section class="quick-search animate-fade-in" aria-labelledby="search-title">
-            <div class="search-card">
-                <form class="search-form" (ngSubmit)="quickTrack()" role="search" aria-label="Quick package tracking">
-                    <div class="form-group">
-                        <label for="quick-tracking" class="form-label">Quick Track Your Package</label>
-                        <input 
-                            type="text" 
-                            id="quick-tracking" 
-                            class="form-input" 
-                            placeholder="Enter tracking number (e.g., GLX123456789)"
-                            aria-describedby="tracking-help"
-                            [(ngModel)]="trackingNumber"
-                            name="trackingNumber"
-                        >
-                    </div>
-                    <button type="submit" class="btn btn-primary search-btn">
-                        <i class="fas fa-search" aria-hidden="true"></i>
-                        Track Now
-                    </button>
-                </form>
-                <div id="tracking-help" class="sr-only">Enter your tracking number to get instant package status</div>
-            </div>
-        </section>
-
-        <!-- ===== NAVIGATION TABS ===== -->
-        <nav class="nav-tabs animate-fade-in" role="tablist" aria-label="Help categories">
-            <button 
-                class="nav-tab" 
-                [class.active]="currentTab === 'tracking-advice'"
-                role="tab" 
-                [attr.aria-selected]="currentTab === 'tracking-advice'"
-                aria-controls="tracking-advice" 
-                id="advice-tab" 
-                (click)="switchTab('tracking-advice')"
-            >
-                <i class="fas fa-lightbulb" aria-hidden="true"></i>
-                Tracking Advice
-            </button>
-            <button 
-                class="nav-tab" 
-                [class.active]="currentTab === 'tracking-tools'"
-                role="tab" 
-                [attr.aria-selected]="currentTab === 'tracking-tools'"
-                aria-controls="tracking-tools" 
-                id="tools-tab" 
-                (click)="switchTab('tracking-tools')"
-            >
-                <i class="fas fa-tools" aria-hidden="true"></i>
-                Tracking Tools
-            </button>
-            <button 
-                class="nav-tab" 
-                [class.active]="currentTab === 'faqs'"
-                role="tab" 
-                [attr.aria-selected]="currentTab === 'faqs'"
-                aria-controls="faqs" 
-                id="faqs-tab" 
-                (click)="switchTab('faqs')"
-            >
-                <i class="fas fa-question-circle" aria-hidden="true"></i>
-                FAQs
-            </button>
-            <button 
-                class="nav-tab" 
-                [class.active]="currentTab === 'contact-us'"
-                role="tab" 
-                [attr.aria-selected]="currentTab === 'contact-us'"
-                aria-controls="contact-us" 
-                id="contact-tab" 
-                (click)="switchTab('contact-us')"
-            >
-                <i class="fas fa-headset" aria-hidden="true"></i>
-                Contact Us
-            </button>
-        </nav>
-
-        <!-- ===== TAB CONTENT ===== -->
-        <div [ngSwitch]="currentTab">
-            <app-tracking-advice *ngSwitchCase="'tracking-advice'" class="tab-content active"></app-tracking-advice>
-            <app-tracking-tools *ngSwitchCase="'tracking-tools'" class="tab-content active"></app-tracking-tools>
-            <app-faqs *ngSwitchCase="'faqs'" class="tab-content active"></app-faqs>
-            <app-contact-us *ngSwitchCase="'contact-us'" class="tab-content active"></app-contact-us>
+    <!-- ===== QUICK SEARCH ===== -->
+    <section
+      class="quick-search animate-fade-in"
+      aria-labelledby="search-title"
+    >
+      <div class="search-card">
+        <app-quick-track
+          label="Quick Track Your Package"
+          placeholder="Enter tracking number (e.g., GLX123456789)"
+          buttonText="Track Now"
+        ></app-quick-track>
+        <div id="tracking-help" class="sr-only">
+          Enter your tracking number to get instant package status
         </div>
+      </div>
+    </section>
+
+    <!-- ===== NAVIGATION TABS ===== -->
+    <nav
+      class="nav-tabs animate-fade-in"
+      role="tablist"
+      aria-label="Help categories"
+    >
+      <button
+        class="nav-tab"
+        [class.active]="currentTab === 'tracking-advice'"
+        role="tab"
+        [attr.aria-selected]="currentTab === 'tracking-advice'"
+        aria-controls="tracking-advice"
+        id="advice-tab"
+        (click)="switchTab('tracking-advice')"
+      >
+        <i class="fas fa-lightbulb" aria-hidden="true"></i>
+        Tracking Advice
+      </button>
+      <button
+        class="nav-tab"
+        [class.active]="currentTab === 'tracking-tools'"
+        role="tab"
+        [attr.aria-selected]="currentTab === 'tracking-tools'"
+        aria-controls="tracking-tools"
+        id="tools-tab"
+        (click)="switchTab('tracking-tools')"
+      >
+        <i class="fas fa-tools" aria-hidden="true"></i>
+        Tracking Tools
+      </button>
+      <button
+        class="nav-tab"
+        [class.active]="currentTab === 'faqs'"
+        role="tab"
+        [attr.aria-selected]="currentTab === 'faqs'"
+        aria-controls="faqs"
+        id="faqs-tab"
+        (click)="switchTab('faqs')"
+      >
+        <i class="fas fa-question-circle" aria-hidden="true"></i>
+        FAQs
+      </button>
+      <button
+        class="nav-tab"
+        [class.active]="currentTab === 'contact-us'"
+        role="tab"
+        [attr.aria-selected]="currentTab === 'contact-us'"
+        aria-controls="contact-us"
+        id="contact-tab"
+        (click)="switchTab('contact-us')"
+      >
+        <i class="fas fa-headset" aria-hidden="true"></i>
+        Contact Us
+      </button>
+    </nav>
+
+    <!-- ===== TAB CONTENT ===== -->
+    <div [ngSwitch]="currentTab">
+      <app-tracking-advice
+        *ngSwitchCase="'tracking-advice'"
+        class="tab-content active"
+      ></app-tracking-advice>
+      <app-tracking-tools
+        *ngSwitchCase="'tracking-tools'"
+        class="tab-content active"
+      ></app-tracking-tools>
+      <app-faqs *ngSwitchCase="'faqs'" class="tab-content active"></app-faqs>
+      <app-contact-us
+        *ngSwitchCase="'contact-us'"
+        class="tab-content active"
+      ></app-contact-us>
     </div>
-</main> 
+  </div>
+</main>

--- a/src/app/pages/help/help.component.ts
+++ b/src/app/pages/help/help.component.ts
@@ -2,10 +2,9 @@ import { Component, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { Router, ActivatedRoute, NavigationEnd } from '@angular/router';
 import { filter } from 'rxjs/operators';
-import { NotificationService } from '../../shared/services/notification.service';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
+import { QuickTrackComponent } from '../../shared/components/quick-track/quick-track.component';
 import { TrackingAdviceComponent } from './tracking-advice/tracking-advice.component';
 import { TrackingToolsComponent } from './tracking-tools/tracking-tools.component';
 import { FaqsComponent } from './faqs/faqs.component';
@@ -16,41 +15,39 @@ import { ContactUsComponent } from './contact-us/contact-us.component';
   standalone: true,
   imports: [
     CommonModule,
-    FormsModule,
     RouterModule,
+    QuickTrackComponent,
     TrackingAdviceComponent,
     TrackingToolsComponent,
     FaqsComponent,
-    ContactUsComponent
+    ContactUsComponent,
   ],
   templateUrl: './help.component.html',
-  styleUrls: ['./help.component.scss']
+  styleUrls: ['./help.component.scss'],
 })
 export class HelpComponent implements OnInit {
   currentTab: string = 'tracking-advice';
-  trackingNumber: string = '';
 
   constructor(
     private titleService: Title,
     private router: Router,
     private route: ActivatedRoute,
-    private notificationService: NotificationService
   ) {
     // Subscribe to route changes to handle fragment navigation
-    this.router.events.pipe(
-      filter(event => event instanceof NavigationEnd)
-    ).subscribe(() => {
-      const fragment = this.route.snapshot.fragment;
-      if (fragment) {
-        this.handleFragmentNavigation(fragment);
-      }
-    });
+    this.router.events
+      .pipe(filter((event) => event instanceof NavigationEnd))
+      .subscribe(() => {
+        const fragment = this.route.snapshot.fragment;
+        if (fragment) {
+          this.handleFragmentNavigation(fragment);
+        }
+      });
   }
 
   ngOnInit() {
     this.titleService.setTitle('Tracking Help & Support - Globex Logistics');
     this.initializeAccessibility();
-    
+
     // Handle initial fragment if present
     const fragment = this.route.snapshot.fragment;
     if (fragment) {
@@ -78,22 +75,30 @@ export class HelpComponent implements OnInit {
   switchTab(tab: string) {
     this.currentTab = tab;
     // Update URL fragment without triggering a navigation
-    const fragment = tab === 'tracking-advice' ? 'advice' :
-                    tab === 'tracking-tools' ? 'tools' :
-                    tab === 'faqs' ? 'faq' :
-                    tab === 'contact-us' ? 'contact' : '';
-    
+    const fragment =
+      tab === 'tracking-advice'
+        ? 'advice'
+        : tab === 'tracking-tools'
+          ? 'tools'
+          : tab === 'faqs'
+            ? 'faq'
+            : tab === 'contact-us'
+              ? 'contact'
+              : '';
+
     this.router.navigate([], {
       fragment,
       relativeTo: this.route,
-      replaceUrl: true
+      replaceUrl: true,
     });
   }
 
   private initializeAccessibility() {
     // Add ARIA labels to interactive elements
-    const interactiveElements = document.querySelectorAll('[onclick], [role="button"]');
-    interactiveElements.forEach(element => {
+    const interactiveElements = document.querySelectorAll(
+      '[onclick], [role="button"]',
+    );
+    interactiveElements.forEach((element) => {
       if (!element.hasAttribute('tabindex')) {
         element.setAttribute('tabindex', '0');
       }
@@ -102,42 +107,17 @@ export class HelpComponent implements OnInit {
     this.announceToScreenReader('Tracking help center loaded');
   }
 
-  quickTrack() {
-    if (!this.trackingNumber) {
-      this.notificationService.show('Please enter a tracking number', 'warning');
-      return;
-    }
-
-    this.notificationService.show(`Tracking package ${this.trackingNumber}...`, 'info');
-    
-    setTimeout(() => {
-      this.router.navigate(['/tracking'], {
-        queryParams: { 
-          number: this.trackingNumber,
-          type: 'quick'
-        }
-      });
-    }, 1500);
-  }
-
   private announceToScreenReader(message: string) {
     const announcement = document.createElement('div');
     announcement.setAttribute('aria-live', 'polite');
     announcement.setAttribute('aria-atomic', 'true');
     announcement.className = 'sr-only';
     announcement.textContent = message;
-    
+
     document.body.appendChild(announcement);
-    
+
     setTimeout(() => {
       document.body.removeChild(announcement);
     }, 1000);
   }
-
-  onTrackingSubmit(): void {
-    if (this.trackingNumber) {
-      // Implement tracking logic
-      console.log('Tracking number submitted:', this.trackingNumber);
-    }
-  }
-} 
+}

--- a/src/app/shared/components/navbar/navbar.component.html
+++ b/src/app/shared/components/navbar/navbar.component.html
@@ -1,98 +1,117 @@
 <header class="header">
-    <nav class="navbar">
-      <a class="navbar__logo" routerLink="/">FedEx</a>
-  
-      <button class="navbar__toggle" (click)="toggleMobileMenu()">
-        <i class="fas" [ngClass]="{'fa-bars': !isMobileMenuOpen, 'fa-times': isMobileMenuOpen}"></i>
+  <nav class="navbar">
+    <a class="navbar__logo" routerLink="/">FedEx</a>
+
+    <button class="navbar__toggle" (click)="toggleMobileMenu()">
+      <i
+        class="fas"
+        [ngClass]="{
+          'fa-bars': !isMobileMenuOpen,
+          'fa-times': isMobileMenuOpen,
+        }"
+      ></i>
+    </button>
+
+    <ul class="navbar__menu" [class.active]="isMobileMenuOpen">
+      <li>
+        <a
+          routerLink="/"
+          routerLinkActive="active"
+          [routerLinkActiveOptions]="{ exact: true }"
+          >Home</a
+        >
+      </li>
+
+      <li class="dropdown">
+        <a class="dropdown-toggle" (click)="toggleDropdown($event, 'tracking')">
+          Tracking <i class="fas fa-chevron-down"></i>
+        </a>
+        <ul class="dropdown__menu" [class.show]="activeDropdown === 'tracking'">
+          <li>
+            <h4>Tracking ID</h4>
+            <app-quick-track
+              placeholder="Insert Tracking ID Number"
+              buttonText="TRACK"
+            ></app-quick-track>
+          </li>
+          <li><hr /></li>
+          <li>
+            <a routerLink="/tracking" [queryParams]="{ type: 'advanced' }">
+              Advanced Shipment Tracking
+            </a>
+          </li>
+          <li>
+            <a routerLink="/advanced-tracking">
+              Advanced Shipment Management
+            </a>
+          </li>
+          <li>
+            <a routerLink="/tracking" [queryParams]="{ type: 'mobile' }">
+              Track by Mobile
+            </a>
+          </li>
+          <li>
+            <a routerLink="/tracking">
+              <strong>All Tracking Services</strong>
+            </a>
+          </li>
+        </ul>
+      </li>
+
+      <li>
+        <a routerLink="/history" routerLinkActive="active">History</a>
+      </li>
+
+      <li class="dropdown">
+        <a class="dropdown-toggle" (click)="toggleDropdown($event, 'help')">
+          Help <i class="fas fa-chevron-down"></i>
+        </a>
+        <ul class="dropdown__menu" [class.show]="activeDropdown === 'help'">
+          <li><a routerLink="/help" fragment="advice">Advice</a></li>
+          <li><a routerLink="/help" fragment="tools">Tracking Tools</a></li>
+          <li><a routerLink="/help" fragment="faq">Tracking FAQs</a></li>
+          <li><a routerLink="/help" fragment="contact">Contact Us</a></li>
+        </ul>
+      </li>
+
+      <li>
+        <a routerLink="/about" routerLinkActive="active">About</a>
+      </li>
+      <li>
+        <a routerLink="/news" routerLinkActive="active">News</a>
+      </li>
+      <li>
+        <a routerLink="/find-location" routerLinkActive="active"
+          >Find Location</a
+        >
+      </li>
+
+      <li>
+        <a routerLink="/notifications" routerLinkActive="active">
+          <i class="fas fa-bell"></i>
+          <span class="notification-badge" *ngIf="notificationCount > 0">{{
+            notificationCount
+          }}</span>
+        </a>
+      </li>
+
+      <li>
+        <a routerLink="/auth/login" routerLinkActive="active">
+          <i class="fas fa-user-circle"></i> Login/Register
+        </a>
+      </li>
+    </ul>
+
+    <div class="navbar__search">
+      <button class="search-btn" (click)="toggleSearch()">
+        <i class="fas fa-search"></i>
       </button>
-  
-      <ul class="navbar__menu" [class.active]="isMobileMenuOpen">
-        <li><a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">Home</a></li>
-  
-        <li class="dropdown">
-          <a class="dropdown-toggle" (click)="toggleDropdown($event, 'tracking')">
-            Tracking <i class="fas fa-chevron-down"></i>
-          </a>
-          <ul class="dropdown__menu" [class.show]="activeDropdown === 'tracking'">
-            <li>
-              <h4>Tracking ID</h4>
-              <div class="tracking-input-group">
-                <input type="text" [(ngModel)]="quickTrackingNumber" placeholder="Insert Tracking ID Number" />
-                <button class="btn-track" (click)="quickTrack()">
-                  TRACK <i class="fas fa-arrow-right"></i>
-                </button>
-              </div>
-            </li>
-            <li><hr /></li>
-            <li>
-              <a routerLink="/tracking" [queryParams]="{type: 'advanced'}">
-                Advanced Shipment Tracking
-              </a>
-            </li>
-            <li>
-              <a routerLink="/advanced-tracking">
-                Advanced Shipment Management
-              </a>
-            </li>
-            <li>
-              <a routerLink="/tracking" [queryParams]="{type: 'mobile'}">
-                Track by Mobile
-              </a>
-            </li>
-            <li>
-              <a routerLink="/tracking">
-                <strong>All Tracking Services</strong>
-              </a>
-            </li>
-          </ul>
-        </li>
-  
-        <li>
-          <a routerLink="/history" routerLinkActive="active">History</a>
-        </li>
-  
-        <li class="dropdown">
-          <a class="dropdown-toggle" (click)="toggleDropdown($event, 'help')">
-            Help <i class="fas fa-chevron-down"></i>
-          </a>
-          <ul class="dropdown__menu" [class.show]="activeDropdown === 'help'">
-            <li><a routerLink="/help" fragment="advice">Advice</a></li>
-            <li><a routerLink="/help" fragment="tools">Tracking Tools</a></li>
-            <li><a routerLink="/help" fragment="faq">Tracking FAQs</a></li>
-            <li><a routerLink="/help" fragment="contact">Contact Us</a></li>
-          </ul>
-        </li>
-  
-        <li>
-          <a routerLink="/about" routerLinkActive="active">About</a>
-        </li>
-        <li>
-          <a routerLink="/news" routerLinkActive="active">News</a>
-        </li>
-        <li>
-          <a routerLink="/find-location" routerLinkActive="active">Find Location</a>
-        </li>
-  
-        <li>
-          <a routerLink="/notifications" routerLinkActive="active">
-            <i class="fas fa-bell"></i>
-            <span class="notification-badge" *ngIf="notificationCount > 0">{{ notificationCount }}</span>
-          </a>
-        </li>
-  
-        <li>
-          <a routerLink="/auth/login" routerLinkActive="active">
-            <i class="fas fa-user-circle"></i> Login/Register
-          </a>
-        </li>
-      </ul>
-  
-      <div class="navbar__search">
-        <button class="search-btn" (click)="toggleSearch()">
-          <i class="fas fa-search"></i>
-        </button>
-        <input *ngIf="showSearch" type="text" class="search-input" placeholder="Rechercher..." />
-      </div>
-    </nav>
-  </header>
-  
+      <input
+        *ngIf="showSearch"
+        type="text"
+        class="search-input"
+        placeholder="Rechercher..."
+      />
+    </div>
+  </nav>
+</header>

--- a/src/app/shared/components/navbar/navbar.component.ts
+++ b/src/app/shared/components/navbar/navbar.component.ts
@@ -1,22 +1,21 @@
 import { Component, OnInit, HostListener, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
-import { FormsModule } from '@angular/forms';
 import { Router, NavigationEnd } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
+import { QuickTrackComponent } from '../quick-track/quick-track.component';
 
 @Component({
   selector: 'app-navbar',
   standalone: true,
-  imports: [CommonModule, RouterModule, FormsModule],
+  imports: [CommonModule, RouterModule, QuickTrackComponent],
   templateUrl: './navbar.component.html',
-  styleUrls: ['./navbar.component.scss']
+  styleUrls: ['./navbar.component.scss'],
 })
 export class NavbarComponent implements OnInit, OnDestroy {
   showSearch = false;
   notificationCount = 0;
-  quickTrackingNumber: string = '';
   activeDropdown: string | null = null;
   isMobileMenuOpen = false;
   private routerSubscription: Subscription;
@@ -24,11 +23,11 @@ export class NavbarComponent implements OnInit, OnDestroy {
 
   constructor(private router: Router) {
     // S'abonner aux événements de navigation pour fermer les menus
-    this.routerSubscription = this.router.events.pipe(
-      filter(event => event instanceof NavigationEnd)
-    ).subscribe(() => {
-      this.closeAllMenus();
-    });
+    this.routerSubscription = this.router.events
+      .pipe(filter((event) => event instanceof NavigationEnd))
+      .subscribe(() => {
+        this.closeAllMenus();
+      });
   }
 
   ngOnInit(): void {
@@ -59,19 +58,6 @@ export class NavbarComponent implements OnInit, OnDestroy {
     }
   }
 
-  quickTrack(): void {
-    if (this.quickTrackingNumber?.trim()) {
-      this.router.navigate(['/tracking'], {
-        queryParams: { 
-          number: this.quickTrackingNumber.trim(),
-          type: 'quick'
-        }
-      });
-      this.quickTrackingNumber = '';
-      this.closeAllMenus();
-    }
-  }
-
   toggleMobileMenu(): void {
     this.isMobileMenuOpen = !this.isMobileMenuOpen;
     if (!this.isMobileMenuOpen) {
@@ -82,7 +68,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
   toggleDropdown(event: Event, dropdown: string): void {
     event.preventDefault();
     event.stopPropagation();
-    
+
     if (this.activeDropdown === dropdown) {
       this.activeDropdown = null;
     } else {
@@ -92,8 +78,13 @@ export class NavbarComponent implements OnInit, OnDestroy {
     // Sur mobile, ajuster le scroll pour voir le menu déroulant
     if (!this.isDesktop && this.activeDropdown) {
       setTimeout(() => {
-        const dropdownElement = (event.target as HTMLElement).closest('.dropdown');
-        dropdownElement?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        const dropdownElement = (event.target as HTMLElement).closest(
+          '.dropdown',
+        );
+        dropdownElement?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'nearest',
+        });
       }, 100);
     }
   }
@@ -101,9 +92,11 @@ export class NavbarComponent implements OnInit, OnDestroy {
   @HostListener('document:click', ['$event'])
   onDocumentClick(event: MouseEvent): void {
     const target = event.target as HTMLElement;
-    if (!target.closest('.dropdown') && 
-        !target.closest('.navbar__toggle') && 
-        !target.closest('.navbar__search')) {
+    if (
+      !target.closest('.dropdown') &&
+      !target.closest('.navbar__toggle') &&
+      !target.closest('.navbar__search')
+    ) {
       this.closeAllMenus();
     }
   }

--- a/src/app/shared/components/quick-track/quick-track.component.html
+++ b/src/app/shared/components/quick-track/quick-track.component.html
@@ -1,0 +1,23 @@
+<form
+  (ngSubmit)="track()"
+  class="quick-track-form"
+  role="search"
+  aria-label="Quick package tracking"
+>
+  <div class="form-group" *ngIf="label">
+    <label [for]="'qt-number'" class="form-label">{{ label }}</label>
+  </div>
+  <div class="tracking-input-group">
+    <input
+      type="text"
+      id="qt-number"
+      [placeholder]="placeholder"
+      [(ngModel)]="trackingNumber"
+      name="trackingNumber"
+      class="quick-input"
+    />
+    <button type="submit" class="btn-track">
+      {{ buttonText }}
+    </button>
+  </div>
+</form>

--- a/src/app/shared/components/quick-track/quick-track.component.scss
+++ b/src/app/shared/components/quick-track/quick-track.component.scss
@@ -1,0 +1,21 @@
+.quick-track-form {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-end;
+}
+
+.quick-input {
+  flex: 1;
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+.btn-track {
+  padding: 0.5rem 1rem;
+  background: #4d148c;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/src/app/shared/components/quick-track/quick-track.component.spec.ts
+++ b/src/app/shared/components/quick-track/quick-track.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { QuickTrackComponent } from './quick-track.component';
+
+describe('QuickTrackComponent', () => {
+  let component: QuickTrackComponent;
+  let fixture: ComponentFixture<QuickTrackComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [QuickTrackComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(QuickTrackComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/quick-track/quick-track.component.ts
+++ b/src/app/shared/components/quick-track/quick-track.component.ts
@@ -1,0 +1,44 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Router, RouterModule } from '@angular/router';
+import { NotificationService } from '../../services/notification.service';
+
+@Component({
+  selector: 'app-quick-track',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterModule],
+  templateUrl: './quick-track.component.html',
+  styleUrls: ['./quick-track.component.scss'],
+})
+export class QuickTrackComponent {
+  /** Placeholder for the input field */
+  @Input() placeholder: string = 'Enter tracking number';
+  /** Optional label displayed above the input */
+  @Input() label?: string;
+  /** Text displayed inside the submit button */
+  @Input() buttonText: string = 'Track';
+
+  trackingNumber = '';
+
+  constructor(
+    private router: Router,
+    private notificationService: NotificationService,
+  ) {}
+
+  track(): void {
+    const number = this.trackingNumber.trim();
+    if (!number) {
+      this.notificationService.show(
+        'Please enter a tracking number',
+        'warning',
+      );
+      return;
+    }
+
+    this.router.navigate(['/tracking'], {
+      queryParams: { number, type: 'quick' },
+    });
+    this.trackingNumber = '';
+  }
+}


### PR DESCRIPTION
## Summary
- create QuickTrack component with basic form logic
- replace tracking form in help page with new component
- swap navbar tracking input for the new component

## Testing
- `npx prettier -w src/app/shared/components/quick-track/quick-track.component.ts src/app/shared/components/quick-track/quick-track.component.html src/app/shared/components/quick-track/quick-track.component.scss src/app/shared/components/quick-track/quick-track.component.spec.ts src/app/pages/help/help.component.ts src/app/pages/help/help.component.html src/app/shared/components/navbar/navbar.component.ts src/app/shared/components/navbar/navbar.component.html`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find Angular modules)*

------
https://chatgpt.com/codex/tasks/task_e_684cf37ee3c4832e8ddc176c57526158