### PR TITLE
Add FAQ service and refactor component

### DIFF
--- a/src/app/pages/help/faqs/faqs.component.ts
+++ b/src/app/pages/help/faqs/faqs.component.ts
@@ -1,13 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-
-interface FAQ {
-  question: string;
-  answer: string;
-  isOpen: boolean;
-  category: string;
-}
+import { FAQ } from '../../../shared/models/faq.model';
+import { FaqService } from '../../../shared/services/faq.service';
 
 @Component({
   selector: 'app-faqs',
@@ -16,7 +11,7 @@ interface FAQ {
   templateUrl: './faqs.component.html',
   styleUrls: ['./faqs.component.scss']
 })
-export class FaqsComponent {
+export class FaqsComponent implements OnInit {
   selectedCategory: string = 'all';
   searchQuery: string = '';
 
@@ -29,56 +24,15 @@ export class FaqsComponent {
     { id: 'technical', name: 'Technical Help' }
   ];
 
-  faqs: FAQ[] = [
-    {
-      question: 'How do I track my package?',
-      answer: 'Enter your tracking number in the search box on our homepage or in the quick track section. You can also track through our mobile app or by email notifications if you\'ve set those up.',
-      isOpen: false,
-      category: 'tracking'
-    },
-    {
-      question: 'What do the different tracking statuses mean?',
-      answer: 'Common statuses include: "In Transit" (package is moving), "Out for Delivery" (will be delivered today), "Delivered" (package has arrived), and "Exception" (delivery issue). Check our status guide for more details.',
-      isOpen: false,
-      category: 'status'
-    },
-    {
-      question: 'My tracking number isn\'t working, what should I do?',
-      answer: 'First, verify the number is correct. Wait 24-48 hours after shipping as it may take time to appear in our system. If still not working, contact our support team.',
-      isOpen: false,
-      category: 'tracking'
-    },
-    {
-      question: 'How often is tracking information updated?',
-      answer: 'Tracking information is typically updated every 2-4 hours, but may vary depending on the shipping carrier and location. Enable notifications to get real-time updates.',
-      isOpen: false,
-      category: 'status'
-    },
-    {
-      question: 'Can I track multiple packages at once?',
-      answer: 'Yes! Use our bulk tracking tool to track up to 25 packages simultaneously. You can also create an account to save and manage multiple tracking numbers.',
-      isOpen: false,
-      category: 'tracking'
-    },
-    {
-      question: 'What should I do if my package is delayed?',
-      answer: 'Check the tracking details for any exception notices. Weather, customs, or local events may cause delays. If delayed more than 48 hours, contact the carrier or our support.',
-      isOpen: false,
-      category: 'delivery'
-    },
-    {
-      question: 'How do I set up email notifications?',
-      answer: 'Go to your account settings, select "Notification Preferences," and choose your preferred notification types. You can get updates for status changes, delivery attempts, and more.',
-      isOpen: false,
-      category: 'account'
-    },
-    {
-      question: 'Is there a mobile app available?',
-      answer: 'Yes! Our mobile app is available for both iOS and Android devices. Download from the App Store or Google Play Store for on-the-go tracking.',
-      isOpen: false,
-      category: 'technical'
-    }
-  ];
+  faqs: FAQ[] = [];
+
+  constructor(private faqService: FaqService) {}
+
+  ngOnInit(): void {
+    this.faqService.getFaqs().subscribe(faqs => {
+      this.faqs = faqs;
+    });
+  }
 
   toggleFAQ(faq: FAQ) {
     faq.isOpen = !faq.isOpen;

--- a/src/app/shared/models/faq.model.ts
+++ b/src/app/shared/models/faq.model.ts
@@ -2,4 +2,10 @@ export interface FAQ {
   question: string;
   answer: string;
   isOpen: boolean;
+  /**
+   * Optional category used to group FAQs.
+   * Components that don't require categorization
+   * can simply ignore this field.
+   */
+  category?: string;
 }

--- a/src/app/shared/services/faq.service.ts
+++ b/src/app/shared/services/faq.service.ts
@@ -1,0 +1,73 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { FAQ } from '../models/faq.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FaqService {
+  // Static list used as a fallback/demo data
+  private faqs: FAQ[] = [
+    {
+      question: 'How do I track my package?',
+      answer: 'Enter your tracking number in the search box on our homepage or in the quick track section. You can also track through our mobile app or by email notifications if you\'ve set those up.',
+      isOpen: false,
+      category: 'tracking'
+    },
+    {
+      question: 'What do the different tracking statuses mean?',
+      answer: 'Common statuses include: "In Transit" (package is moving), "Out for Delivery" (will be delivered today), "Delivered" (package has arrived), and "Exception" (delivery issue). Check our status guide for more details.',
+      isOpen: false,
+      category: 'status'
+    },
+    {
+      question: 'My tracking number isn\'t working, what should I do?',
+      answer: 'First, verify the number is correct. Wait 24-48 hours after shipping as it may take time to appear in our system. If still not working, contact our support team.',
+      isOpen: false,
+      category: 'tracking'
+    },
+    {
+      question: 'How often is tracking information updated?',
+      answer: 'Tracking information is typically updated every 2-4 hours, but may vary depending on the shipping carrier and location. Enable notifications to get real-time updates.',
+      isOpen: false,
+      category: 'status'
+    },
+    {
+      question: 'Can I track multiple packages at once?',
+      answer: 'Yes! Use our bulk tracking tool to track up to 25 packages simultaneously. You can also create an account to save and manage multiple tracking numbers.',
+      isOpen: false,
+      category: 'tracking'
+    },
+    {
+      question: 'What should I do if my package is delayed?',
+      answer: 'Check the tracking details for any exception notices. Weather, customs, or local events may cause delays. If delayed more than 48 hours, contact the carrier or our support.',
+      isOpen: false,
+      category: 'delivery'
+    },
+    {
+      question: 'How do I set up email notifications?',
+      answer: 'Go to your account settings, select "Notification Preferences," and choose your preferred notification types. You can get updates for status changes, delivery attempts, and more.',
+      isOpen: false,
+      category: 'account'
+    },
+    {
+      question: 'Is there a mobile app available?',
+      answer: 'Yes! Our mobile app is available for both iOS and Android devices. Download from the App Store or Google Play Store for on-the-go tracking.',
+      isOpen: false,
+      category: 'technical'
+    }
+  ];
+
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Retrieve FAQs. Replace the returned value with the HTTP
+   * request below when the backend endpoint is available.
+   */
+  getFaqs(): Observable<FAQ[]> {
+    // return this.http.get<FAQ[]>(`${environment.apiUrl}/faqs`);
+    return of(this.faqs);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add shared `FaqService` with placeholder data
- update FAQ model with optional `category`
- refactor `FaqsComponent` to fetch FAQs from service

## Testing
- `npm run build` *(fails: ng not found)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf3810cf8832e83d257e79b73e880