### PR TITLE
Replace deprecated notificationService.show usages

### DIFF
--- a/src/app/pages/help/help.component.ts
+++ b/src/app/pages/help/help.component.ts
@@ -104,11 +104,11 @@ export class HelpComponent implements OnInit {
 
   quickTrack() {
     if (!this.trackingNumber) {
-      this.notificationService.show('Please enter a tracking number', 'warning');
+      this.notificationService.warning('Please enter a tracking number', '');
       return;
     }
 
-    this.notificationService.show(`Tracking package ${this.trackingNumber}...`, 'info');
+    this.notificationService.info(`Tracking package ${this.trackingNumber}...`, '');
     
     setTimeout(() => {
       this.router.navigate(['/tracking'], {

--- a/src/app/pages/help/tracking-advice/tracking-advice.component.ts
+++ b/src/app/pages/help/tracking-advice/tracking-advice.component.ts
@@ -13,26 +13,26 @@ export class TrackingAdviceComponent {
   constructor(private notificationService: NotificationService) {}
 
   openTrackingGuide() {
-    this.notificationService.show('Opening comprehensive tracking guide...', 'info');
+    this.notificationService.info('Opening comprehensive tracking guide...', '');
   }
 
   openStatusGuide() {
-    this.notificationService.show('Opening status definitions guide...', 'info');
+    this.notificationService.info('Opening status definitions guide...', '');
   }
 
   openTroubleshooting() {
-    this.notificationService.show('Opening troubleshooting wizard...', 'info');
+    this.notificationService.info('Opening troubleshooting wizard...', '');
   }
 
   setupNotifications() {
-    this.notificationService.show('Opening notification preferences...', 'info');
+    this.notificationService.info('Opening notification preferences...', '');
   }
 
   viewDeliveryTimes() {
-    this.notificationService.show('Opening delivery time calculator...', 'info');
+    this.notificationService.info('Opening delivery time calculator...', '');
   }
 
   learnSecurity() {
-    this.notificationService.show('Opening security information...', 'info');
+    this.notificationService.info('Opening security information...', '');
   }
 } 

--- a/src/app/pages/help/tracking-tools/tracking-tools.component.ts
+++ b/src/app/pages/help/tracking-tools/tracking-tools.component.ts
@@ -13,26 +13,26 @@ export class TrackingToolsComponent {
   constructor(private notificationService: NotificationService) {}
 
   openBulkTracking() {
-    this.notificationService.show('Opening bulk tracking tool...', 'info');
+    this.notificationService.info('Opening bulk tracking tool...', '');
   }
 
   openMobileApp() {
-    this.notificationService.show('Opening mobile app download page...', 'info');
+    this.notificationService.info('Opening mobile app download page...', '');
   }
 
   openAPI() {
-    this.notificationService.show('Opening API documentation...', 'info');
+    this.notificationService.info('Opening API documentation...', '');
   }
 
   openEmailTracking() {
-    this.notificationService.show('Opening email tracking setup...', 'info');
+    this.notificationService.info('Opening email tracking setup...', '');
   }
 
   openReports() {
-    this.notificationService.show('Opening tracking reports...', 'info');
+    this.notificationService.info('Opening tracking reports...', '');
   }
 
   openIntegrations() {
-    this.notificationService.show('Opening integration options...', 'info');
+    this.notificationService.info('Opening integration options...', '');
   }
 } 


### PR DESCRIPTION
## Summary
- use `warning` and `info` helpers instead of `show`
- keep message content but remove deprecated type arguments

## Testing
- `npm ci`
- `npx tsc -p tsconfig.app.json`

------
https://chatgpt.com/codex/tasks/task_e_684cf388ef74832e8d793ea45edc226d