### PR TITLE
Remove unused filterFaqs

### DIFF
--- a/src/app/pages/help/faqs/faqs.component.ts
+++ b/src/app/pages/help/faqs/faqs.component.ts
@@ -97,9 +97,4 @@ export class FaqsComponent {
   selectCategory(categoryId: string) {
     this.selectedCategory = categoryId;
   }
-
-  filterFaqs(): void {
-    // Implement FAQ filtering logic
-    console.log('Filtering FAQs with:', this.searchQuery);
-  }
-} 
+}


### PR DESCRIPTION
## Summary
- clean up FAQ component by removing the unused `filterFaqs` method

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_684cf38edba8832eb28729c68a814b30