### PR TITLE
Use notification service in tracking views

### DIFF
--- a/src/app/features/tracking/components/all-tracking/all-tracking.component.ts
+++ b/src/app/features/tracking/components/all-tracking/all-tracking.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule, Router } from '@angular/router';
+import { NotificationService } from '../../../../shared/services/notification.service';
 
 // TODO: Backend - Create Tracking Interfaces
 interface TrackingRequest {
@@ -63,7 +64,7 @@ export class AllTrackingComponent implements OnInit {
     private router: Router,
     // TODO: Inject services
     // private trackingService: TrackingService,
-    // private notificationService: NotificationService
+    private notificationService: NotificationService
   ) {}
 
   ngOnInit(): void {
@@ -103,7 +104,7 @@ export class AllTrackingComponent implements OnInit {
 
   async startBarcodeScanner(): Promise<void> {
     if (!this.isMobile) {
-      alert('Le scanner de code-barres est disponible uniquement sur mobile.');
+      this.notificationService.warning('Scanner indisponible', 'Le scanner de code-barres est disponible uniquement sur mobile.');
       return;
     }
 
@@ -118,14 +119,14 @@ export class AllTrackingComponent implements OnInit {
       */
       
       // Simulation for development
-      alert('Scanner de code-barres activé!\n\n(Fonctionnalité à intégrer avec l\'API caméra)');
+      this.notificationService.success('Scanner activé', "Scanner de code-barres activé!\n\n(Fonctionnalité à intégrer avec l'API caméra)");
       setTimeout(() => {
         this.trackingNumber = 'GBX123456789';
         this.validateInput('tracking', this.trackingNumber);
       }, 2000);
     } catch (error) {
       console.error('Barcode scanning error:', error);
-      alert('Erreur lors du scan du code-barres.');
+      this.notificationService.error('Erreur', 'Erreur lors du scan du code-barres.');
     }
   }
 
@@ -147,7 +148,7 @@ export class AllTrackingComponent implements OnInit {
       
       // Simulation for development
       console.log('Tracking package:', this.trackingNumber);
-      alert(`Recherche du colis: ${this.trackingNumber}\n\n(Intégration API à venir)`);
+      this.notificationService.info('Recherche', `Recherche du colis: ${this.trackingNumber}\n\n(Intégration API à venir)`);
       this.router.navigate(['/tracking/result'], {
         queryParams: {
           number: this.trackingNumber,
@@ -173,7 +174,7 @@ export class AllTrackingComponent implements OnInit {
         reference: this.referenceNumber,
         country: this.selectedCountry
       });
-      alert(`Recherche par référence: ${this.referenceNumber}\nPays: ${this.selectedCountry}\n\n(Intégration API à venir)`);
+      this.notificationService.info('Recherche', `Recherche par référence: ${this.referenceNumber}\nPays: ${this.selectedCountry}\n\n(Intégration API à venir)`);
       this.router.navigate(['/tracking/result'], {
         queryParams: {
           number: this.referenceNumber,
@@ -198,7 +199,7 @@ export class AllTrackingComponent implements OnInit {
         tcn: this.tcnNumber,
         shipDate: this.shipDate
       });
-      alert(`Recherche TCN: ${this.tcnNumber}\nDate: ${this.shipDate}\n\n(Intégration API à venir)`);
+      this.notificationService.info('Recherche', `Recherche TCN: ${this.tcnNumber}\nDate: ${this.shipDate}\n\n(Intégration API à venir)`);
       this.router.navigate(['/tracking/result'], {
         queryParams: {
           number: this.tcnNumber,
@@ -220,7 +221,7 @@ export class AllTrackingComponent implements OnInit {
     try {
       // TODO: Implement proof of delivery download
       console.log('Getting proof of delivery for:', this.proofNumber);
-      alert(`Téléchargement de la preuve de livraison pour: ${this.proofNumber}\n\n(Intégration API à venir)`);
+      this.notificationService.info('Téléchargement', `Téléchargement de la preuve de livraison pour: ${this.proofNumber}\n\n(Intégration API à venir)`);
     } catch (error) {
       console.error('Proof of delivery error:', error);
     } finally {

--- a/src/app/features/tracking/components/tracking-result/tracking-result.component.ts
+++ b/src/app/features/tracking/components/tracking-result/tracking-result.component.ts
@@ -252,7 +252,7 @@ export class TrackingResultComponent implements OnInit, AfterViewInit {
   copyToClipboard(): void {
     const trackingLink = `${window.location.origin}/tracking/${this.trackingNumber}`;
     navigator.clipboard.writeText(trackingLink).then(() => {
-      alert('Tracking link copied to clipboard!');
+      this.notificationService.success('Lien copié', 'Tracking link copied to clipboard!');
       this.showShareDropdown = false;
     });
   }
@@ -290,18 +290,18 @@ export class TrackingResultComponent implements OnInit, AfterViewInit {
       recipient: this.trackingData?.recipient?.name
     }));
     
-    alert('Tracking saved to favorites!');
+    this.notificationService.success('Enregistré', 'Tracking saved to favorites!');
     this.showSaveDropdown = false;
   }
   
   downloadAsPDF(): void {
     this.showSaveDropdown = false;
-    alert('PDF download functionality would be implemented here.\n\nPlease install file-saver package to enable this feature.');
+    this.notificationService.info('Information', 'PDF download functionality would be implemented here.\n\nPlease install file-saver package to enable this feature.');
   }
   
   downloadAsExcel(): void {
     this.showSaveDropdown = false;
-    alert('Excel download functionality would be implemented here.\n\nPlease install xlsx package to enable this feature.');
+    this.notificationService.info('Information', 'Excel download functionality would be implemented here.\n\nPlease install xlsx package to enable this feature.');
   }
   
   // ==== MODAL METHODS ====
@@ -408,12 +408,12 @@ export class TrackingResultComponent implements OnInit, AfterViewInit {
   // ==== ADDITIONAL SERVICES ====
   requestProofOfDelivery(): void {
     // API call to request proof of delivery
-    alert('La preuve de livraison serait affichée ici');
+    this.notificationService.info('Information', 'La preuve de livraison serait affichée ici');
   }
   
   openCustomsClearanceInfo(): void {
     // This would typically open a modal or navigate to customs info page
-    alert('Customs clearance information would display here');
+    this.notificationService.info('Information', 'Customs clearance information would display here');
   }
 
   retry(): void {


### PR DESCRIPTION
## Summary
- replace `alert()` calls in tracking pages with `NotificationService`
- inject `NotificationService` into tracking components

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: several TS errors)*
- `npx ng build --configuration production --verbose` *(fails with build errors)*

------
https://chatgpt.com/codex/tasks/task_e_684cf3edb638832eab4d7c7187a99aff