### PR TITLE
Integrate Angular Material for tracking forms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^16.0.0",
+        "@angular/cdk": "^16.2.14",
         "@angular/common": "^16.0.0",
         "@angular/compiler": "^16.0.0",
         "@angular/core": "^16.0.0",
         "@angular/forms": "^16.2.12",
+        "@angular/material": "^16.2.14",
         "@angular/platform-browser": "^16.0.0",
         "@angular/platform-browser-dynamic": "^16.0.0",
         "@angular/router": "^16.0.0",
@@ -586,6 +588,23 @@
         "@angular/core": "16.2.12"
       }
     },
+    "node_modules/@angular/cdk": {
+      "version": "16.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-16.2.14.tgz",
+      "integrity": "sha512-n6PrGdiVeSTEmM/HEiwIyg6YQUUymZrb5afaNLGFRM5YL0Y8OBqd+XhCjb0OfD/AfgCUtedVEPwNqrfW8KzgGw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "optionalDependencies": {
+        "parse5": "^7.1.2"
+      },
+      "peerDependencies": {
+        "@angular/common": "^16.0.0 || ^17.0.0",
+        "@angular/core": "^16.0.0 || ^17.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
     "node_modules/@angular/cli": {
       "version": "16.0.6",
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-16.0.6.tgz",
@@ -854,6 +873,71 @@
         "@angular/common": "16.2.12",
         "@angular/core": "16.2.12",
         "@angular/platform-browser": "16.2.12",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/material": {
+      "version": "16.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-16.2.14.tgz",
+      "integrity": "sha512-zQIxUb23elPfiIvddqkIDYqQhAHa9ZwMblfbv+ug8bxr4D0Dw360jIarxCgMjAcLj7Ccl3GBqZMUnVeM6cjthw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/auto-init": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/banner": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/card": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/checkbox": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/chips": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/circular-progress": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/data-table": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dialog": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/drawer": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/fab": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/floating-label": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/form-field": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/icon-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/image-list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/layout-grid": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/line-ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/linear-progress": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu-surface": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/notched-outline": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/radio": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/segmented-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/select": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/slider": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/snackbar": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/switch": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-bar": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-scroller": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/textfield": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tooltip": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/top-app-bar": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": "^16.0.0 || ^17.0.0",
+        "@angular/cdk": "16.2.14",
+        "@angular/common": "^16.0.0 || ^17.0.0",
+        "@angular/core": "^16.0.0 || ^17.0.0",
+        "@angular/forms": "^16.0.0 || ^17.0.0",
+        "@angular/platform-browser": "^16.0.0 || ^17.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -3466,6 +3550,808 @@
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@material/animation": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-leRf+BcZTfC/iSigLXnYgcHAGvFVQveoJT5+2PIRdyPI/bIG7hhciRgacHRsCKC0sGya81dDblLgdkjSUemYLw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/auto-init": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/auto-init/-/auto-init-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-uxzDq7q3c0Bu1pAsMugc1Ik9ftQYQqZY+5e2ybNplT8gTImJhNt4M2mMiMHbMANk2l3UgICmUyRSomgPBWCPIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/banner": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/banner/-/banner-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-SHeVoidCUFVhXANN6MNWxK9SZoTSgpIP8GZB7kAl52BywLxtV+FirTtLXkg/8RUkxZRyRWl7HvQ0ZFZa7QQAyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/base": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Fc3vGuOf+duGo22HTRP6dHdc+MUe0VqQfWOuKrn/wXKD62m0QQR2TqJd3rRhCumH557T5QUyheW943M3E+IGfg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/button": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/button/-/button-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-3AQgwrPZCTWHDJvwgKq7Cj+BurQ4wTjDdGL+FEnIGUAjJDskwi1yzx5tW2Wf/NxIi7IoPFyOY3UB41jwMiOrnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/card": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/card/-/card-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-nPlhiWvbLmooTnBmV5gmzB0eLWSgLKsSRBYAbIBmO76Okgz1y+fQNLag+lpm/TDaHVsn5fmQJH8e0zIg0rYsQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/checkbox": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/checkbox/-/checkbox-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-4tpNnO1L0IppoMF3oeQn8F17t2n0WHB0D7mdJK9rhrujen/fLbekkIC82APB3fdGtLGg3qeNqDqPsJm1YnmrwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/chips": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/chips/-/chips-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-fqHKvE5bSWK0bXVkf57MWxZtytGqYBZvvHIOs4JI9HPHEhaJy4CpSw562BEtbm3yFxxALoQknvPW2KYzvADnmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/checkbox": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "safevalues": "^0.3.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/circular-progress": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/circular-progress/-/circular-progress-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Lxe8BGAxQwCQqrLhrYrIP0Uok10h7aYS3RBXP41ph+5GmwJd5zdyE2t93qm2dyThvU6qKuXw9726Dtq/N+wvZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/progress-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/data-table": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/data-table/-/data-table-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-j/7qplT9+sUpfe4pyWhPbl01qJA+OoNAG3VMJruBBR461ZBKyTi7ssKH9yksFGZ8eCEPkOsk/+kDxsiZvRWkeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/checkbox": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/icon-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/linear-progress": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/select": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/density": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/density/-/density-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Zt3u07fXrBWLW06Tl5fgvjicxNQMkFdawLyNTzZ5TvbXfVkErILLePwwGaw8LNcvzqJP6ABLA8jiR+sKNoJQCg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/dialog": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/dialog/-/dialog-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-o+9a/fmwJ9+gY3Z/uhj/PMVJDq7it1NTWKJn2GwAKdB+fDkT4hb9qEdcxMPyvJJ5ups+XiKZo03+tZrD+38c1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/icon-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/dom": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-ly78R7aoCJtundSUu0UROU+5pQD5Piae0Y1MkN6bs0724azeazX1KeXFeaf06JOXnlr5/41ol+fSUPowjoqnOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/drawer": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/drawer/-/drawer-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-PFL4cEFnt7VTxDsuspFVNhsFDYyumjU0VWfj3PWB7XudsEfQ3lo85D3HCEtTTbRsCainGN8bgYNDNafLBqiigw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/elevation": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Ro+Pk8jFuap+T0B0shA3xI1hs2b89dNQ2EIPCNjNMp87emHKAzJfhKb7EZGIwv3+gFLlVaLyIVkb94I89KLsyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/fab": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/fab/-/fab-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-dvU0KWMRglwJEQwmQtFAmJcAjzg9VFF6Aqj78bJYu/DAIGFJ1VTTTSgoXM/XCm1YyQEZ7kZRvxBO37CH54rSDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/feature-targeting": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-wkDjVcoVEYYaJvun28IXdln/foLgPD7n9ZC9TY76GErGCwTq+HWpU6wBAAk+ePmpRFDayw4vI4wBlaWGxLtysQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/floating-label": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/floating-label/-/floating-label-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-bUWPtXzZITOD/2mkvLkEPO1ngDWmb74y0Kgbz6llHLOQBtycyJIpuoQJ1q2Ez0NM/tFLwPphhAgRqmL3YQ/Kzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/focus-ring": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/focus-ring/-/focus-ring-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-cZHThVose3GvAlJzpJoBI1iqL6d1/Jj9hXrR+r8Mwtb1hBIUEG3hxfsRd4vGREuzROPlf0OgNf/V+YHoSwgR5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0"
+      }
+    },
+    "node_modules/@material/form-field": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/form-field/-/form-field-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-+JFXy5X44Gue1CbZZAQ6YejnI203lebYwL0i6k0ylDpWHEOdD5xkF2PyHR28r9/65Ebcbwbff6q7kI1SGoT7MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/icon-button": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/icon-button/-/icon-button-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-1a0MHgyIwOs4RzxrVljsqSizGYFlM1zY2AZaLDsgT4G3kzsplTx8HZQ022GpUCjAygW+WLvg4z1qAhQHvsbqlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/image-list": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/image-list/-/image-list-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-WKWmiYap2iu4QdqmeUSliLlN4O2Ueqa0OuVAYHn/TCzmQ2xmnhZ1pvDLbs6TplpOmlki7vFfe+aSt5SU9gwfOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/layout-grid": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/layout-grid/-/layout-grid-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-5GqmT6oTZhUGWIb+CLD0ZNyDyTiJsr/rm9oRIi3+vCujACwxFkON9tzBlZohdtFS16nuzUusthN6Jt9UrJcN6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/line-ripple": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/line-ripple/-/line-ripple-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-8S30WXEuUdgDdBulzUDlPXD6qMzwCX9SxYb5mGDYLwl199cpSGdXHtGgEcCjokvnpLhdZhcT1Dsxeo1g2Evh5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/linear-progress": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/linear-progress/-/linear-progress-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-6EJpjrz6aoH2/gXLg9iMe0yF2C42hpQyZoHpmcgTLKeci85ktDvJIjwup8tnk8ULQyFiGiIrhXw2v2RSsiFjvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/progress-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/list": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/list/-/list-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-TQ1ppqiCMQj/P7bGD4edbIIv4goczZUoiUAaPq/feb1dflvrFMzYqJ7tQRRCyBL8nRhJoI2x99tk8Q2RXvlGUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/menu": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/menu/-/menu-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-IlAh61xzrzxXs38QZlt74UYt8J431zGznSzDtB1Fqs6YFNd11QPKoiRXn1J2Qu/lUxbFV7i8NBKMCKtia0n6/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu-surface": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/menu-surface": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/menu-surface/-/menu-surface-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-dMtSPN+olTWE+08M5qe4ea1IZOhVryYqzK0Gyb2u1G75rSArUxCOB5rr6OC/ST3Mq3RS6zGuYo7srZt4534K9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/notched-outline": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/notched-outline/-/notched-outline-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-WuurMg44xexkvLTBTnsO0A+qnzFjpcPdvgWBGstBepYozsvSF9zJGdb1x7Zv1MmqbpYh/Ohnuxtb/Y3jOh6irg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/floating-label": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/progress-indicator": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/progress-indicator/-/progress-indicator-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-uOnsvqw5F2fkeTnTl4MrYzjI7KCLmmLyZaM0cgLNuLsWVlddQE+SGMl28tENx7DUK3HebWq0FxCP8f25LuDD+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/radio": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/radio/-/radio-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-ehzOK+U1IxQN+OQjgD2lsnf1t7t7RAwQzeO6Czkiuid29ookYbQynWuLWk7NW8H8ohl7lnmfqTP1xSNkkL/F0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/ripple": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-JfLW+g3GMVDv4cruQ19+HUxpKVdWCldFlIPw1UYezz2h3WTNDy05S3uP2zUdXzZ01C3dkBFviv4nqZ0GCT16MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/rtl": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-SkKLNLFp5QtG7/JEFg9R92qq4MzTcZ5As6sWbH7rRg6ahTHoJEuqE+pOb9Vrtbj84k5gtX+vCYPvCILtSlr2uw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/segmented-button": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/segmented-button/-/segmented-button-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-YDwkCWP9l5mIZJ7pZJZ2hMDxfBlIGVJ+deNzr8O+Z7/xC5LGXbl4R5aPtUVHygvXAXxpf5096ZD+dSXzYzvWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/select": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/select/-/select-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-unfOWVf7T0sixVG+3k3RTuATfzqvCF6QAzA6J9rlCh/Tq4HuIBNDdV4z19IVu4zwmgWYxY0iSvqWUvdJJYwakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/floating-label": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/line-ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu-surface": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/notched-outline": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/shape": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/shape/-/shape-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Dsvr771ZKC46ODzoixLdGwlLEQLfxfLrtnRojXABoZf5G3o9KtJU+J+5Ld5aa960OAsCzzANuaub4iR88b1guA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/slider": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/slider/-/slider-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-3AEu+7PwW4DSNLndue47dh2u7ga4hDJRYmuu7wnJCIWJBnLCkp6C92kNc4Rj5iQY2ftJio5aj1gqryluh5tlYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/snackbar": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/snackbar/-/snackbar-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-TwwQSYxfGK6mc03/rdDamycND6o+1p61WNd7ElZv1F1CLxB4ihRjbCoH7Qo+oVDaP8CTpjeclka+24RLhQq0mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/icon-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/switch": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/switch/-/switch-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-OjUjtT0kRz1ASAsOS+dNzwMwvsjmqy5edK57692qmrP6bL4GblFfBDoiNJ6t0AN4OaKcmL5Hy/xNrTdOZW7Qqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "safevalues": "^0.3.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tab/-/tab-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-s/L9otAwn/pZwVQZBRQJmPqYeNbjoEbzbjMpDQf/VBG/6dJ+aP03ilIBEkqo8NVnCoChqcdtVCoDNRtbU+yp6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab-bar": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-bar/-/tab-bar-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Xmtq0wJGfu5k+zQeFeNsr4bUKv7L+feCmUp/gsapJ655LQKMXOUQZtSv9ZqWOfrCMy55hoF1CzGFV+oN3tyWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-scroller": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab-indicator": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-indicator/-/tab-indicator-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-despCJYi1GrDDq7F2hvLQkObHnSLZPPDxnOzU16zJ6FNYvIdszgfzn2HgAZ6pl5hLOexQ8cla6cAqjTDuaJBhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab-scroller": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-scroller/-/tab-scroller-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-QWHG/EWxirj4V9u2IHz+OSY9XCWrnNrPnNgEufxAJVUKV/A8ma1DYeFSQqxhX709R8wKGdycJksg0Flkl7Gq7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/textfield": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/textfield/-/textfield-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-R3qRex9kCaZIAK8DuxPnVC42R0OaW7AB7fsFknDKeTeVQvRcbnV8E+iWSdqTiGdsi6QQHifX8idUrXw+O45zPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/floating-label": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/line-ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/notched-outline": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/theme": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-CpUwXGE0dbhxQ45Hu9r9wbJtO/MAlv5ER4tBHA9tp/K+SU+lDgurBE2touFMg5INmdfVNtdumxb0nPPLaNQcUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tokens": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-nbEuGj05txWz6ZMUanpM47SaAD7soyjKILR+XwDell9Zg3bGhsnexCNXPEz2fD+YgomS+jM5XmIcaJJHg/H93Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0"
+      }
+    },
+    "node_modules/@material/tooltip": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tooltip/-/tooltip-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-UzuXp0b9NuWuYLYpPguxrjbJnCmT/Cco8CkjI/6JajxaeA3o2XEBbQfRMTq8PTafuBjCHTc0b0mQY7rtxUp1Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "safevalues": "^0.3.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/top-app-bar": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/top-app-bar/-/top-app-bar-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-vJWjsvqtdSD5+yQ/9vgoBtBSCvPJ5uF/DVssv8Hdhgs1PYaAcODUi77kdi0+sy/TaWyOsTkQixqmwnFS16zesA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/touch-target": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-AqYh9fjt+tv4ZE0C6MeYHblS2H+XwLbDl2mtyrK0DOEnCVQk5/l5ImKDfhrUdFWHvS4a5nBM4AA+sa7KaroLoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/typography": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-CKsG1zyv34AKPNyZC8olER2OdPII64iR2SzQjpqh1UUvmIFiMPk23LvQ1OnC5aCB14pOXzmVgvJt31r9eNdZ6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
     },
     "node_modules/@ngtools/webpack": {
       "version": "16.2.16",
@@ -10651,7 +11537,7 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -10692,7 +11578,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -11754,6 +12640,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/safevalues": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/safevalues/-/safevalues-0.3.4.tgz",
+      "integrity": "sha512-LRneZZRXNgjzwG4bDQdOTSbze3fHm1EAKN/8bePxnlEZiBmkYEDggaHbuvHI9/hoqHbGfsEA7tWS9GhYHZBBsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/sass": {
       "version": "1.64.1",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "^16.0.0",
+    "@angular/cdk": "^16.2.14",
     "@angular/common": "^16.0.0",
     "@angular/compiler": "^16.0.0",
     "@angular/core": "^16.0.0",
     "@angular/forms": "^16.2.12",
+    "@angular/material": "^16.2.14",
     "@angular/platform-browser": "^16.0.0",
     "@angular/platform-browser-dynamic": "^16.0.0",
     "@angular/router": "^16.0.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormsModule } from '@angular/forms';
 
 import { AppRoutingModule } from './app-routing.module';
@@ -24,6 +25,7 @@ import { NotificationComponent } from './shared/components/notification/notifica
   ],
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
     AppRoutingModule,
     FormsModule
   ],

--- a/src/app/features/tracking/components/all-tracking/all-tracking.component.html
+++ b/src/app/features/tracking/components/all-tracking/all-tracking.component.html
@@ -18,55 +18,20 @@
     </p>
 
     <!-- ===== TRACKING TABS ===== -->
-    <div class="tracking-tabs">
-      <button 
-        class="tracking-tab" 
-        [class.active]="activeTab === 'tracking-number'"
-        (click)="showTab('tracking-number')">
-        Tracking number
-      </button>
-      <button 
-        class="tracking-tab" 
-        [class.active]="activeTab === 'track-reference'"
-        (click)="showTab('track-reference')">
-        Track by reference
-      </button>
-      <button 
-        class="tracking-tab" 
-        [class.active]="activeTab === 'track-tcn'"
-        (click)="showTab('track-tcn')">
-        Track by TCN
-      </button>
-      <button 
-        class="tracking-tab" 
-        [class.active]="activeTab === 'proof-delivery'"
-        (click)="showTab('proof-delivery')">
-        Obtain proof of delivery
-      </button>
-    </div>
+    <mat-tab-group [selectedIndex]="tabIndex" (selectedIndexChange)="tabChange($event)" class="tracking-content">
 
-    <!-- ===== TRACKING CONTENT ===== -->
-    <div class="tracking-content">
-      
       <!-- Track by Number -->
-      <div class="tracking-panel" [class.active]="activeTab === 'tracking-number'">
+      <mat-tab label="Tracking number">
+        <div class="tracking-panel">
         <p class="tracking-description">
           Enter up to 30 of your Globex tracking, door tag, or Globex Office order numbers (one per line).
         </p>
-        
+
         <form class="tracking-form" (ngSubmit)="trackPackage($event)">
-          <div class="form-group">
-            <label class="form-label" for="trackingInput">Tracking number*</label>
-            <input 
-              type="text" 
-              id="trackingInput"
-              class="form-input" 
-              placeholder="Enter tracking number"
-              [(ngModel)]="trackingNumber"
-              name="trackingNumber"
-              (input)="validateInput('tracking', trackingNumber)"
-            >
-          </div>
+          <mat-form-field appearance="fill" class="w-100">
+            <mat-label>Tracking number*</mat-label>
+            <input matInput placeholder="Enter tracking number" [(ngModel)]="trackingNumber" name="trackingNumber" (input)="validateInput('tracking', trackingNumber)">
+          </mat-form-field>
 
           <!-- ===== SCAN BARCODE SECTION ===== -->
           <div class="scan-section">
@@ -87,154 +52,107 @@
           </div>
 
           <a href="#" class="need-help">NEED HELP?</a>
-          
+
           <div style="text-align: center;">
-            <button 
-              type="submit" 
-              class="track-btn" 
-              [class.enabled]="isTrackingValid"
-              [disabled]="!isTrackingValid || isLoading">
+            <button mat-raised-button color="primary" type="submit" [disabled]="!isTrackingValid || isLoading">
               <span *ngIf="!isLoading">TRACK</span>
               <span *ngIf="isLoading">TRACKING...</span>
             </button>
           </div>
         </form>
-      </div>
+        </div>
+      </mat-tab>
 
       <!-- Track by Reference -->
-      <div class="tracking-panel" [class.active]="activeTab === 'track-reference'">
+      <mat-tab label="Track by reference">
+        <div class="tracking-panel">
         <p class="tracking-description">
           Enter your reference number or purchase order numbers.
         </p>
-        
+
         <form class="tracking-form" (ngSubmit)="trackByReference($event)">
-          <div class="form-group">
-            <label class="form-label" for="referenceInput">Reference number*</label>
-            <input 
-              type="text" 
-              id="referenceInput"
-              class="form-input" 
-              placeholder="Enter reference number"
-              [(ngModel)]="referenceNumber"
-              name="referenceNumber"
-              (input)="validateInput('reference', referenceNumber)"
-            >
-          </div>
-          
-          <div class="form-group">
-            <label class="form-label" for="countrySelect">Destination country/territory*</label>
-            <select 
-              id="countrySelect" 
-              class="form-select"
-              [(ngModel)]="selectedCountry"
-              name="selectedCountry"
-              (change)="validateInput('reference', referenceNumber)">
-              <option value="">Select country</option>
-              <option value="FR">France</option>
-              <option value="DE">Germany</option>
-              <option value="ES">Spain</option>
-              <option value="IT">Italy</option>
-              <option value="UK">United Kingdom</option>
-              <option value="US">United States</option>
-            </select>
-          </div>
+          <mat-form-field appearance="fill" class="w-100">
+            <mat-label>Reference number*</mat-label>
+            <input matInput placeholder="Enter reference number" [(ngModel)]="referenceNumber" name="referenceNumber" (input)="validateInput('reference', referenceNumber)">
+          </mat-form-field>
+
+          <mat-form-field appearance="fill" class="w-100">
+            <mat-label>Destination country/territory*</mat-label>
+            <mat-select [(ngModel)]="selectedCountry" name="selectedCountry" (selectionChange)="validateInput('reference', referenceNumber)">
+              <mat-option value="">Select country</mat-option>
+              <mat-option value="FR">France</mat-option>
+              <mat-option value="DE">Germany</mat-option>
+              <mat-option value="ES">Spain</mat-option>
+              <mat-option value="IT">Italy</mat-option>
+              <mat-option value="UK">United Kingdom</mat-option>
+              <mat-option value="US">United States</mat-option>
+            </mat-select>
+          </mat-form-field>
 
           <a href="#" class="need-help">NEED HELP?</a>
-          
+
           <div style="text-align: center;">
-            <button 
-              type="submit" 
-              class="track-btn" 
-              [class.enabled]="isReferenceValid"
-              [disabled]="!isReferenceValid || isLoading">
+            <button mat-raised-button color="primary" type="submit" [disabled]="!isReferenceValid || isLoading">
               <span *ngIf="!isLoading">TRACK</span>
               <span *ngIf="isLoading">TRACKING...</span>
             </button>
           </div>
         </form>
-      </div>
+        </div>
+      </mat-tab>
 
       <!-- Track by TCN -->
-      <div class="tracking-panel" [class.active]="activeTab === 'track-tcn'">
+      <mat-tab label="Track by TCN">
+        <div class="tracking-panel">
         <p class="tracking-description">
           Enter your Transportation Control Number (TCN) for government orders.<br>
           Do not use any spaces or the letters "TCN" preceding the number.
         </p>
-        
+
         <form class="tracking-form" (ngSubmit)="trackByTCN($event)">
-          <div class="form-group">
-            <label class="form-label" for="tcnInput">Enter TCN or tracking number*</label>
-            <input 
-              type="text" 
-              id="tcnInput"
-              class="form-input" 
-              placeholder="Enter TCN"
-              [(ngModel)]="tcnNumber"
-              name="tcnNumber"
-              (input)="validateInput('tcn', tcnNumber)"
-            >
-          </div>
-          
-          <div class="form-group">
-            <label class="form-label" for="shipDate">Ship date*</label>
-            <div style="position: relative;">
-              <input 
-                type="date" 
-                id="shipDate"
-                class="form-input"
-                [(ngModel)]="shipDate"
-                name="shipDate"
-                (change)="validateInput('tcn', tcnNumber)"
-              >
-              <i class="fas fa-calendar" style="position: absolute; right: 15px; top: 50%; transform: translateY(-50%); color: #4d148c; pointer-events: none;"></i>
-            </div>
-            <div class="form-help">Please enter the ship date if the package was shipped more than 14 days ago.</div>
-          </div>
+          <mat-form-field appearance="fill" class="w-100">
+            <mat-label>Enter TCN or tracking number*</mat-label>
+            <input matInput placeholder="Enter TCN" [(ngModel)]="tcnNumber" name="tcnNumber" (input)="validateInput('tcn', tcnNumber)">
+          </mat-form-field>
+
+          <mat-form-field appearance="fill" class="w-100">
+            <mat-label>Ship date*</mat-label>
+            <input matInput type="date" [(ngModel)]="shipDate" name="shipDate" (dateChange)="validateInput('tcn', tcnNumber)">
+            <div mat-hint>Please enter the ship date if the package was shipped more than 14 days ago.</div>
+          </mat-form-field>
 
           <a href="#" class="need-help">NEED HELP?</a>
-          
+
           <div style="text-align: center;">
-            <button 
-              type="submit" 
-              class="track-btn" 
-              [class.enabled]="isTCNValid"
-              [disabled]="!isTCNValid || isLoading">
+            <button mat-raised-button color="primary" type="submit" [disabled]="!isTCNValid || isLoading">
               <span *ngIf="!isLoading">TRACK</span>
               <span *ngIf="isLoading">TRACKING...</span>
             </button>
           </div>
         </form>
-      </div>
+        </div>
+      </mat-tab>
 
       <!-- Proof of Delivery -->
-      <div class="tracking-panel" [class.active]="activeTab === 'proof-delivery'">
+      <mat-tab label="Obtain proof of delivery">
+        <div class="tracking-panel">
         <form class="tracking-form" (ngSubmit)="getProofOfDelivery($event)">
-          <div class="form-group">
-            <label class="form-label" for="proofInput">Tracking ID*</label>
-            <input 
-              type="text" 
-              id="proofInput"
-              class="form-input" 
-              placeholder="Enter your tracking ID"
-              [(ngModel)]="proofNumber"
-              name="proofNumber"
-              (input)="validateInput('proof', proofNumber)"
-            >
-          </div>
-          
+          <mat-form-field appearance="fill" class="w-100">
+            <mat-label>Tracking ID*</mat-label>
+            <input matInput placeholder="Enter your tracking ID" [(ngModel)]="proofNumber" name="proofNumber" (input)="validateInput('proof', proofNumber)">
+          </mat-form-field>
+
           <div style="text-align: center;">
-            <button 
-              type="submit" 
-              class="track-btn enabled" 
-              [class.enabled]="isProofValid"
-              [disabled]="!isProofValid || isLoading">
+            <button mat-raised-button color="primary" type="submit" [disabled]="!isProofValid || isLoading">
               <span *ngIf="!isLoading">DOWNLOAD</span>
               <span *ngIf="isLoading">DOWNLOADING...</span>
             </button>
           </div>
         </form>
-      </div>
-    </div>
+        </div>
+      </mat-tab>
+
+    </mat-tab-group>
   </div>
 </main>
 

--- a/src/app/features/tracking/components/all-tracking/all-tracking.component.scss
+++ b/src/app/features/tracking/components/all-tracking/all-tracking.component.scss
@@ -84,36 +84,6 @@ body {
   margin-right: auto;
 }
 
-// Tracking Tabs
-.tracking-tabs {
-  display: flex;
-  justify-content: center;
-  margin-bottom: 40px;
-  border-bottom: 1px solid var(--border-color);
-}
-
-.tracking-tab {
-  background: none;
-  border: none;
-  padding: 15px 30px;
-  font-size: 16px;
-  font-weight: 500;
-  color: var(--text-light);
-  cursor: pointer;
-  border-bottom: 3px solid transparent;
-  transition: var(--transition);
-
-  &.active {
-    color: var(--white);
-    background-color: var(--primary-purple);
-    border-bottom-color: var(--primary-purple);
-  }
-
-  &:hover:not(.active) {
-    color: var(--primary-purple);
-    background-color: var(--light-gray);
-  }
-}
 
 // Tracking Content
 .tracking-content {
@@ -122,16 +92,11 @@ body {
 }
 
 .tracking-panel {
-  display: none;
   background-color: var(--white);
   padding: 40px;
   border-radius: 8px;
   box-shadow: var(--shadow);
   border-top: 4px solid var(--primary-purple);
-
-  &.active {
-    display: block;
-  }
 }
 
 .tracking-description {
@@ -156,21 +121,6 @@ body {
   color: var(--text-dark);
 }
 
-.form-input,
-.form-select {
-  width: 100%;
-  padding: 15px;
-  border: 2px solid var(--border-color);
-  border-radius: 4px;
-  font-size: 16px;
-  transition: var(--transition);
-
-  &:focus {
-    outline: none;
-    border-color: var(--primary-purple);
-    box-shadow: 0 0 0 3px rgba(77, 20, 140, 0.1);
-  }
-}
 
 .form-help {
   font-size: 14px;
@@ -229,34 +179,6 @@ body {
 }
 
 // Track Button
-.track-btn {
-  background-color: #d0d0d0;
-  color: var(--text-dark);
-  border: none;
-  padding: 15px 40px;
-  border-radius: 4px;
-  font-size: 16px;
-  font-weight: 500;
-  cursor: pointer;
-  margin-top: 20px;
-  transition: var(--transition);
-
-  &.enabled {
-    background: var(--primary-purple);
-    color: var(--white);
-
-    &:hover:not(:disabled) {
-      transform: translateY(-2px);
-      box-shadow: 0 4px 15px rgba(77, 20, 140, 0.3);
-    }
-  }
-
-  &:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-    transform: none;
-  }
-}
 
 .need-help {
   color: var(--secondary-blue);
@@ -385,15 +307,6 @@ body {
     font-size: 32px;
   }
 
-  .tracking-tabs {
-    flex-wrap: wrap;
-    gap: 10px;
-  }
-
-  .tracking-tab {
-    padding: 12px 20px;
-    font-size: 14px;
-  }
 
   .tracking-panel {
     padding: 20px;
@@ -420,19 +333,6 @@ body {
     padding: 40px 0;
   }
 
-  .tracking-tabs {
-    flex-direction: column;
-  }
-
-  .tracking-tab {
-    border-bottom: none;
-    border-left: 3px solid transparent;
-
-    &.active {
-      border-left-color: var(--primary-purple);
-      border-bottom-color: transparent;
-    }
-  }
 
   .tracking-options,
   .mobile-tracking {

--- a/src/app/features/tracking/components/all-tracking/all-tracking.component.ts
+++ b/src/app/features/tracking/components/all-tracking/all-tracking.component.ts
@@ -2,6 +2,12 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule, Router } from '@angular/router';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSelectModule } from '@angular/material/select';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
 
 // TODO: Backend - Create Tracking Interfaces
 interface TrackingRequest {
@@ -35,13 +41,19 @@ interface TrackingEvent {
     CommonModule,
     FormsModule,
     ReactiveFormsModule,
-    RouterModule
+    RouterModule,
+    MatTabsModule,
+    MatInputModule,
+    MatButtonModule,
+    MatSelectModule,
+    MatFormFieldModule,
+    MatIconModule
   ],
   templateUrl: './all-tracking.component.html',
   styleUrls: ['./all-tracking.component.scss']
 })
 export class AllTrackingComponent implements OnInit {
-  activeTab: string = 'tracking-number';
+  tabIndex: number = 0;
   isLoading: boolean = false;
   isMobile: boolean = false;
 
@@ -80,8 +92,9 @@ export class AllTrackingComponent implements OnInit {
     // TODO: Initialize tracking services and configurations
   }
 
-  showTab(tabId: string): void {
-    this.activeTab = tabId;
+
+  tabChange(index: number): void {
+    this.tabIndex = index;
   }
 
   validateInput(type: string, value: string): void {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,6 +1,21 @@
 /* You can add global styles to this file, and also import other style files */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 @import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css');
+@use '@angular/material' as mat;
+
+$fedex-primary: mat.define-palette(mat.$deep-purple-palette, 700);
+$fedex-accent: mat.define-palette(mat.$orange-palette, 600);
+$fedex-warn: mat.define-palette(mat.$red-palette);
+
+$fedex-theme: mat.define-light-theme((
+  color: (
+    primary: $fedex-primary,
+    accent: $fedex-accent,
+    warn: $fedex-warn,
+  )
+));
+
+@include mat.all-component-themes($fedex-theme);
 
 /* Variables CSS globales */
 :root {


### PR DESCRIPTION
## Summary
- install Angular Material
- wire up BrowserAnimationsModule
- refactor tracking component to use Material form fields and tab group
- clean up old styles now handled by Material
- add FedEx-like Material theme

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf3b60bb4832e824bff06a825858f