### PR TITLE
Add help data services

### DIFF
--- a/src/app/pages/help/contact-us/contact-us.component.ts
+++ b/src/app/pages/help/contact-us/contact-us.component.ts
@@ -2,15 +2,8 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { NotificationService } from '../../../shared/services/notification.service';
-
-interface ContactOption {
-  id: string;
-  icon: string;
-  title: string;
-  description: string;
-  link?: string;
-  isForm?: boolean;
-}
+import { ContactOption } from '../../../shared/models/contact-option.model';
+import { HelpContactService } from '../services/help-contact.service';
 
 @Component({
   selector: 'app-contact-us',
@@ -23,40 +16,12 @@ export class ContactUsComponent implements OnInit {
   contactForm: FormGroup;
   selectedOption: string | null = null;
 
-  contactOptions: ContactOption[] = [
-    {
-      id: 'chat',
-      icon: 'fa-comments',
-      title: 'Live Chat',
-      description: 'Chat with our support team in real-time',
-      link: '#chat'
-    },
-    {
-      id: 'email',
-      icon: 'fa-envelope',
-      title: 'Email Support',
-      description: 'Send us a detailed message',
-      isForm: true
-    },
-    {
-      id: 'phone',
-      icon: 'fa-phone-alt',
-      title: 'Phone Support',
-      description: 'Call us at +1 (800) 123-4567',
-      link: 'tel:+18001234567'
-    },
-    {
-      id: 'social',
-      icon: 'fa-users',
-      title: 'Social Media',
-      description: 'Connect with us on social media',
-      link: '#social'
-    }
-  ];
+  contactOptions: ContactOption[] = [];
 
   constructor(
     private fb: FormBuilder,
-    private notificationService: NotificationService
+    private notificationService: NotificationService,
+    private contactService: HelpContactService
   ) {
     this.contactForm = this.fb.group({
       name: ['', [Validators.required, Validators.minLength(2)]],
@@ -68,7 +33,9 @@ export class ContactUsComponent implements OnInit {
     });
   }
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.contactService.getContactOptions().subscribe(options => (this.contactOptions = options));
+  }
 
   selectOption(optionId: string) {
     this.selectedOption = optionId;

--- a/src/app/pages/help/faqs/faqs.component.ts
+++ b/src/app/pages/help/faqs/faqs.component.ts
@@ -1,13 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-
-interface FAQ {
-  question: string;
-  answer: string;
-  isOpen: boolean;
-  category: string;
-}
+import { FAQ } from '../../../shared/models/faq.model';
+import { HelpFaqService } from '../services/help-faq.service';
 
 @Component({
   selector: 'app-faqs',
@@ -16,7 +11,7 @@ interface FAQ {
   templateUrl: './faqs.component.html',
   styleUrls: ['./faqs.component.scss']
 })
-export class FaqsComponent {
+export class FaqsComponent implements OnInit {
   selectedCategory: string = 'all';
   searchQuery: string = '';
 
@@ -29,56 +24,13 @@ export class FaqsComponent {
     { id: 'technical', name: 'Technical Help' }
   ];
 
-  faqs: FAQ[] = [
-    {
-      question: 'How do I track my package?',
-      answer: 'Enter your tracking number in the search box on our homepage or in the quick track section. You can also track through our mobile app or by email notifications if you\'ve set those up.',
-      isOpen: false,
-      category: 'tracking'
-    },
-    {
-      question: 'What do the different tracking statuses mean?',
-      answer: 'Common statuses include: "In Transit" (package is moving), "Out for Delivery" (will be delivered today), "Delivered" (package has arrived), and "Exception" (delivery issue). Check our status guide for more details.',
-      isOpen: false,
-      category: 'status'
-    },
-    {
-      question: 'My tracking number isn\'t working, what should I do?',
-      answer: 'First, verify the number is correct. Wait 24-48 hours after shipping as it may take time to appear in our system. If still not working, contact our support team.',
-      isOpen: false,
-      category: 'tracking'
-    },
-    {
-      question: 'How often is tracking information updated?',
-      answer: 'Tracking information is typically updated every 2-4 hours, but may vary depending on the shipping carrier and location. Enable notifications to get real-time updates.',
-      isOpen: false,
-      category: 'status'
-    },
-    {
-      question: 'Can I track multiple packages at once?',
-      answer: 'Yes! Use our bulk tracking tool to track up to 25 packages simultaneously. You can also create an account to save and manage multiple tracking numbers.',
-      isOpen: false,
-      category: 'tracking'
-    },
-    {
-      question: 'What should I do if my package is delayed?',
-      answer: 'Check the tracking details for any exception notices. Weather, customs, or local events may cause delays. If delayed more than 48 hours, contact the carrier or our support.',
-      isOpen: false,
-      category: 'delivery'
-    },
-    {
-      question: 'How do I set up email notifications?',
-      answer: 'Go to your account settings, select "Notification Preferences," and choose your preferred notification types. You can get updates for status changes, delivery attempts, and more.',
-      isOpen: false,
-      category: 'account'
-    },
-    {
-      question: 'Is there a mobile app available?',
-      answer: 'Yes! Our mobile app is available for both iOS and Android devices. Download from the App Store or Google Play Store for on-the-go tracking.',
-      isOpen: false,
-      category: 'technical'
-    }
-  ];
+  faqs: FAQ[] = [];
+
+  constructor(private faqService: HelpFaqService) {}
+
+  ngOnInit(): void {
+    this.faqService.getFaqs().subscribe(faqs => (this.faqs = faqs));
+  }
 
   toggleFAQ(faq: FAQ) {
     faq.isOpen = !faq.isOpen;

--- a/src/app/pages/help/services/help-contact.service.ts
+++ b/src/app/pages/help/services/help-contact.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { ContactOption } from '../../../shared/models/contact-option.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class HelpContactService {
+  getContactOptions(): Observable<ContactOption[]> {
+    const contactOptions: ContactOption[] = [
+      {
+        id: 'chat',
+        icon: 'fa-comments',
+        title: 'Live Chat',
+        description: 'Chat with our support team in real-time',
+        link: '#chat'
+      },
+      {
+        id: 'email',
+        icon: 'fa-envelope',
+        title: 'Email Support',
+        description: 'Send us a detailed message',
+        isForm: true
+      },
+      {
+        id: 'phone',
+        icon: 'fa-phone-alt',
+        title: 'Phone Support',
+        description: 'Call us at +1 (800) 123-4567',
+        link: 'tel:+18001234567'
+      },
+      {
+        id: 'social',
+        icon: 'fa-users',
+        title: 'Social Media',
+        description: 'Connect with us on social media',
+        link: '#social'
+      }
+    ];
+
+    return of(contactOptions);
+  }
+}

--- a/src/app/pages/help/services/help-faq.service.ts
+++ b/src/app/pages/help/services/help-faq.service.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { FAQ } from '../../../shared/models/faq.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class HelpFaqService {
+  getFaqs(): Observable<FAQ[]> {
+    const faqs: FAQ[] = [
+      {
+        question: 'How do I track my package?',
+        answer: 'Enter your tracking number in the search box on our homepage or in the quick track section. You can also track through our mobile app or by email notifications if you\'ve set those up.',
+        isOpen: false,
+        category: 'tracking'
+      },
+      {
+        question: 'What do the different tracking statuses mean?',
+        answer: 'Common statuses include: "In Transit" (package is moving), "Out for Delivery" (will be delivered today), "Delivered" (package has arrived), and "Exception" (delivery issue). Check our status guide for more details.',
+        isOpen: false,
+        category: 'status'
+      },
+      {
+        question: 'My tracking number isn\'t working, what should I do?',
+        answer: 'First, verify the number is correct. Wait 24-48 hours after shipping as it may take time to appear in our system. If still not working, contact our support team.',
+        isOpen: false,
+        category: 'tracking'
+      },
+      {
+        question: 'How often is tracking information updated?',
+        answer: 'Tracking information is typically updated every 2-4 hours, but may vary depending on the shipping carrier and location. Enable notifications to get real-time updates.',
+        isOpen: false,
+        category: 'status'
+      },
+      {
+        question: 'Can I track multiple packages at once?',
+        answer: 'Yes! Use our bulk tracking tool to track up to 25 packages simultaneously. You can also create an account to save and manage multiple tracking numbers.',
+        isOpen: false,
+        category: 'tracking'
+      },
+      {
+        question: 'What should I do if my package is delayed?',
+        answer: 'Check the tracking details for any exception notices. Weather, customs, or local events may cause delays. If delayed more than 48 hours, contact the carrier or our support.',
+        isOpen: false,
+        category: 'delivery'
+      },
+      {
+        question: 'How do I set up email notifications?',
+        answer: 'Go to your account settings, select "Notification Preferences," and choose your preferred notification types. You can get updates for status changes, delivery attempts, and more.',
+        isOpen: false,
+        category: 'account'
+      },
+      {
+        question: 'Is there a mobile app available?',
+        answer: 'Yes! Our mobile app is available for both iOS and Android devices. Download from the App Store or Google Play Store for on-the-go tracking.',
+        isOpen: false,
+        category: 'technical'
+      }
+    ];
+
+    return of(faqs);
+  }
+}

--- a/src/app/shared/models/contact-option.model.ts
+++ b/src/app/shared/models/contact-option.model.ts
@@ -1,0 +1,8 @@
+export interface ContactOption {
+  id: string;
+  icon: string;
+  title: string;
+  description: string;
+  link?: string;
+  isForm?: boolean;
+}

--- a/src/app/shared/models/faq.model.ts
+++ b/src/app/shared/models/faq.model.ts
@@ -2,4 +2,6 @@ export interface FAQ {
   question: string;
   answer: string;
   isOpen: boolean;
+  /** Optional category used for advanced filtering */
+  category?: string;
 }


### PR DESCRIPTION
## Summary
- create `HelpFaqService` and `HelpContactService`
- move data from help components into the new services
- add `ContactOption` model and extend `FAQ` model with optional category
- update components to load their data from the services

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf3a81ce8832e93e895a78550f3f8