### PR TITLE
Implement help guide routing

### DIFF
--- a/src/app/pages/help/help.routes.ts
+++ b/src/app/pages/help/help.routes.ts
@@ -4,6 +4,18 @@ import { TrackingAdviceComponent } from './tracking-advice/tracking-advice.compo
 import { TrackingToolsComponent } from './tracking-tools/tracking-tools.component';
 import { FaqsComponent } from './faqs/faqs.component';
 import { ContactUsComponent } from './contact-us/contact-us.component';
+import { TrackingGuideComponent } from './tracking-advice/tracking-guide/tracking-guide.component';
+import { StatusGuideComponent } from './tracking-advice/status-guide/status-guide.component';
+import { TroubleshootingComponent } from './tracking-advice/troubleshooting/troubleshooting.component';
+import { NotificationPreferencesComponent } from './tracking-advice/notification-preferences/notification-preferences.component';
+import { DeliveryTimesComponent } from './tracking-advice/delivery-times/delivery-times.component';
+import { SecurityInfoComponent } from './tracking-advice/security-info/security-info.component';
+import { BulkTrackingComponent } from './tracking-tools/bulk-tracking/bulk-tracking.component';
+import { MobileAppComponent } from './tracking-tools/mobile-app/mobile-app.component';
+import { ApiAccessComponent } from './tracking-tools/api-access/api-access.component';
+import { EmailTrackingComponent } from './tracking-tools/email-tracking/email-tracking.component';
+import { TrackingReportsComponent } from './tracking-tools/tracking-reports/tracking-reports.component';
+import { IntegrationsComponent } from './tracking-tools/integrations/integrations.component';
 
 export const HELP_ROUTES: Routes = [
   {
@@ -30,7 +42,55 @@ export const HELP_ROUTES: Routes = [
       {
         path: 'contact',
         component: ContactUsComponent
+      },
+      {
+        path: 'tracking-guide',
+        component: TrackingGuideComponent
+      },
+      {
+        path: 'status-guide',
+        component: StatusGuideComponent
+      },
+      {
+        path: 'troubleshooting',
+        component: TroubleshootingComponent
+      },
+      {
+        path: 'notification-preferences',
+        component: NotificationPreferencesComponent
+      },
+      {
+        path: 'delivery-times',
+        component: DeliveryTimesComponent
+      },
+      {
+        path: 'security-info',
+        component: SecurityInfoComponent
+      },
+      {
+        path: 'bulk-tracking',
+        component: BulkTrackingComponent
+      },
+      {
+        path: 'mobile-app',
+        component: MobileAppComponent
+      },
+      {
+        path: 'api-access',
+        component: ApiAccessComponent
+      },
+      {
+        path: 'email-tracking',
+        component: EmailTrackingComponent
+      },
+      {
+        path: 'tracking-reports',
+        component: TrackingReportsComponent
+      },
+      {
+        path: 'integrations',
+        component: IntegrationsComponent
       }
     ]
   }
-]; 
+];

--- a/src/app/pages/help/tracking-advice/delivery-times/delivery-times.component.html
+++ b/src/app/pages/help/tracking-advice/delivery-times/delivery-times.component.html
@@ -1,0 +1,2 @@
+<h2>Delivery Time Calculator</h2>
+<p>Check typical delivery times and plan accordingly.</p>

--- a/src/app/pages/help/tracking-advice/delivery-times/delivery-times.component.scss
+++ b/src/app/pages/help/tracking-advice/delivery-times/delivery-times.component.scss
@@ -1,0 +1,3 @@
+h2 {
+  margin-bottom: 1rem;
+}

--- a/src/app/pages/help/tracking-advice/delivery-times/delivery-times.component.ts
+++ b/src/app/pages/help/tracking-advice/delivery-times/delivery-times.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-delivery-times',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './delivery-times.component.html',
+  styleUrls: ['./delivery-times.component.scss']
+})
+export class DeliveryTimesComponent {}

--- a/src/app/pages/help/tracking-advice/notification-preferences/notification-preferences.component.html
+++ b/src/app/pages/help/tracking-advice/notification-preferences/notification-preferences.component.html
@@ -1,0 +1,2 @@
+<h2>Notification Preferences</h2>
+<p>Set up how you want to receive tracking updates.</p>

--- a/src/app/pages/help/tracking-advice/notification-preferences/notification-preferences.component.scss
+++ b/src/app/pages/help/tracking-advice/notification-preferences/notification-preferences.component.scss
@@ -1,0 +1,3 @@
+h2 {
+  margin-bottom: 1rem;
+}

--- a/src/app/pages/help/tracking-advice/notification-preferences/notification-preferences.component.ts
+++ b/src/app/pages/help/tracking-advice/notification-preferences/notification-preferences.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-notification-preferences',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './notification-preferences.component.html',
+  styleUrls: ['./notification-preferences.component.scss']
+})
+export class NotificationPreferencesComponent {}

--- a/src/app/pages/help/tracking-advice/security-info/security-info.component.html
+++ b/src/app/pages/help/tracking-advice/security-info/security-info.component.html
@@ -1,0 +1,2 @@
+<h2>Security Information</h2>
+<p>Learn how we keep your data and packages secure.</p>

--- a/src/app/pages/help/tracking-advice/security-info/security-info.component.scss
+++ b/src/app/pages/help/tracking-advice/security-info/security-info.component.scss
@@ -1,0 +1,3 @@
+h2 {
+  margin-bottom: 1rem;
+}

--- a/src/app/pages/help/tracking-advice/security-info/security-info.component.ts
+++ b/src/app/pages/help/tracking-advice/security-info/security-info.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-security-info',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './security-info.component.html',
+  styleUrls: ['./security-info.component.scss']
+})
+export class SecurityInfoComponent {}

--- a/src/app/pages/help/tracking-advice/status-guide/status-guide.component.html
+++ b/src/app/pages/help/tracking-advice/status-guide/status-guide.component.html
@@ -1,0 +1,2 @@
+<h2>Status Definitions Guide</h2>
+<p>Learn what each tracking status means for your shipment.</p>

--- a/src/app/pages/help/tracking-advice/status-guide/status-guide.component.scss
+++ b/src/app/pages/help/tracking-advice/status-guide/status-guide.component.scss
@@ -1,0 +1,3 @@
+h2 {
+  margin-bottom: 1rem;
+}

--- a/src/app/pages/help/tracking-advice/status-guide/status-guide.component.ts
+++ b/src/app/pages/help/tracking-advice/status-guide/status-guide.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-status-guide',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './status-guide.component.html',
+  styleUrls: ['./status-guide.component.scss']
+})
+export class StatusGuideComponent {}

--- a/src/app/pages/help/tracking-advice/tracking-advice.component.ts
+++ b/src/app/pages/help/tracking-advice/tracking-advice.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { NotificationService } from '../../../shared/services/notification.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-tracking-advice',
@@ -10,29 +10,29 @@ import { NotificationService } from '../../../shared/services/notification.servi
   styleUrls: ['./tracking-advice.component.scss']
 })
 export class TrackingAdviceComponent {
-  constructor(private notificationService: NotificationService) {}
+  constructor(private router: Router) {}
 
   openTrackingGuide() {
-    this.notificationService.show('Opening comprehensive tracking guide...', 'info');
+    this.router.navigate(['/help/tracking-guide']);
   }
 
   openStatusGuide() {
-    this.notificationService.show('Opening status definitions guide...', 'info');
+    this.router.navigate(['/help/status-guide']);
   }
 
   openTroubleshooting() {
-    this.notificationService.show('Opening troubleshooting wizard...', 'info');
+    this.router.navigate(['/help/troubleshooting']);
   }
 
   setupNotifications() {
-    this.notificationService.show('Opening notification preferences...', 'info');
+    this.router.navigate(['/help/notification-preferences']);
   }
 
   viewDeliveryTimes() {
-    this.notificationService.show('Opening delivery time calculator...', 'info');
+    this.router.navigate(['/help/delivery-times']);
   }
 
   learnSecurity() {
-    this.notificationService.show('Opening security information...', 'info');
+    this.router.navigate(['/help/security-info']);
   }
-} 
+}

--- a/src/app/pages/help/tracking-advice/tracking-guide/tracking-guide.component.html
+++ b/src/app/pages/help/tracking-advice/tracking-guide/tracking-guide.component.html
@@ -1,0 +1,2 @@
+<h2>Comprehensive Tracking Guide</h2>
+<p>This section provides detailed instructions on how to track your packages.</p>

--- a/src/app/pages/help/tracking-advice/tracking-guide/tracking-guide.component.scss
+++ b/src/app/pages/help/tracking-advice/tracking-guide/tracking-guide.component.scss
@@ -1,0 +1,3 @@
+h2 {
+  margin-bottom: 1rem;
+}

--- a/src/app/pages/help/tracking-advice/tracking-guide/tracking-guide.component.ts
+++ b/src/app/pages/help/tracking-advice/tracking-guide/tracking-guide.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-tracking-guide',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './tracking-guide.component.html',
+  styleUrls: ['./tracking-guide.component.scss']
+})
+export class TrackingGuideComponent {}

--- a/src/app/pages/help/tracking-advice/troubleshooting/troubleshooting.component.html
+++ b/src/app/pages/help/tracking-advice/troubleshooting/troubleshooting.component.html
@@ -1,0 +1,2 @@
+<h2>Troubleshooting Wizard</h2>
+<p>Resolve common tracking problems with this guide.</p>

--- a/src/app/pages/help/tracking-advice/troubleshooting/troubleshooting.component.scss
+++ b/src/app/pages/help/tracking-advice/troubleshooting/troubleshooting.component.scss
@@ -1,0 +1,3 @@
+h2 {
+  margin-bottom: 1rem;
+}

--- a/src/app/pages/help/tracking-advice/troubleshooting/troubleshooting.component.ts
+++ b/src/app/pages/help/tracking-advice/troubleshooting/troubleshooting.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-troubleshooting',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './troubleshooting.component.html',
+  styleUrls: ['./troubleshooting.component.scss']
+})
+export class TroubleshootingComponent {}

--- a/src/app/pages/help/tracking-tools/api-access/api-access.component.html
+++ b/src/app/pages/help/tracking-tools/api-access/api-access.component.html
@@ -1,0 +1,2 @@
+<h2>API Access</h2>
+<p>Integrate tracking into your systems using our API.</p>

--- a/src/app/pages/help/tracking-tools/api-access/api-access.component.scss
+++ b/src/app/pages/help/tracking-tools/api-access/api-access.component.scss
@@ -1,0 +1,3 @@
+h2 {
+  margin-bottom: 1rem;
+}

--- a/src/app/pages/help/tracking-tools/api-access/api-access.component.ts
+++ b/src/app/pages/help/tracking-tools/api-access/api-access.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-api-access',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './api-access.component.html',
+  styleUrls: ['./api-access.component.scss']
+})
+export class ApiAccessComponent {}

--- a/src/app/pages/help/tracking-tools/bulk-tracking/bulk-tracking.component.html
+++ b/src/app/pages/help/tracking-tools/bulk-tracking/bulk-tracking.component.html
@@ -1,0 +1,2 @@
+<h2>Bulk Tracking Tool</h2>
+<p>Upload a list of tracking numbers to monitor them all at once.</p>

--- a/src/app/pages/help/tracking-tools/bulk-tracking/bulk-tracking.component.scss
+++ b/src/app/pages/help/tracking-tools/bulk-tracking/bulk-tracking.component.scss
@@ -1,0 +1,3 @@
+h2 {
+  margin-bottom: 1rem;
+}

--- a/src/app/pages/help/tracking-tools/bulk-tracking/bulk-tracking.component.ts
+++ b/src/app/pages/help/tracking-tools/bulk-tracking/bulk-tracking.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-bulk-tracking',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './bulk-tracking.component.html',
+  styleUrls: ['./bulk-tracking.component.scss']
+})
+export class BulkTrackingComponent {}

--- a/src/app/pages/help/tracking-tools/email-tracking/email-tracking.component.html
+++ b/src/app/pages/help/tracking-tools/email-tracking/email-tracking.component.html
@@ -1,0 +1,2 @@
+<h2>Email Tracking</h2>
+<p>Set up email alerts to get updates directly in your inbox.</p>

--- a/src/app/pages/help/tracking-tools/email-tracking/email-tracking.component.scss
+++ b/src/app/pages/help/tracking-tools/email-tracking/email-tracking.component.scss
@@ -1,0 +1,3 @@
+h2 {
+  margin-bottom: 1rem;
+}

--- a/src/app/pages/help/tracking-tools/email-tracking/email-tracking.component.ts
+++ b/src/app/pages/help/tracking-tools/email-tracking/email-tracking.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-email-tracking',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './email-tracking.component.html',
+  styleUrls: ['./email-tracking.component.scss']
+})
+export class EmailTrackingComponent {}

--- a/src/app/pages/help/tracking-tools/integrations/integrations.component.html
+++ b/src/app/pages/help/tracking-tools/integrations/integrations.component.html
@@ -1,0 +1,2 @@
+<h2>Integrations</h2>
+<p>Connect with popular e-commerce and shipping platforms.</p>

--- a/src/app/pages/help/tracking-tools/integrations/integrations.component.scss
+++ b/src/app/pages/help/tracking-tools/integrations/integrations.component.scss
@@ -1,0 +1,3 @@
+h2 {
+  margin-bottom: 1rem;
+}

--- a/src/app/pages/help/tracking-tools/integrations/integrations.component.ts
+++ b/src/app/pages/help/tracking-tools/integrations/integrations.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-integrations',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './integrations.component.html',
+  styleUrls: ['./integrations.component.scss']
+})
+export class IntegrationsComponent {}

--- a/src/app/pages/help/tracking-tools/mobile-app/mobile-app.component.html
+++ b/src/app/pages/help/tracking-tools/mobile-app/mobile-app.component.html
@@ -1,0 +1,2 @@
+<h2>Mobile App</h2>
+<p>Download our mobile app for tracking on the go.</p>

--- a/src/app/pages/help/tracking-tools/mobile-app/mobile-app.component.scss
+++ b/src/app/pages/help/tracking-tools/mobile-app/mobile-app.component.scss
@@ -1,0 +1,3 @@
+h2 {
+  margin-bottom: 1rem;
+}

--- a/src/app/pages/help/tracking-tools/mobile-app/mobile-app.component.ts
+++ b/src/app/pages/help/tracking-tools/mobile-app/mobile-app.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-mobile-app',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './mobile-app.component.html',
+  styleUrls: ['./mobile-app.component.scss']
+})
+export class MobileAppComponent {}

--- a/src/app/pages/help/tracking-tools/tracking-reports/tracking-reports.component.html
+++ b/src/app/pages/help/tracking-tools/tracking-reports/tracking-reports.component.html
@@ -1,0 +1,2 @@
+<h2>Tracking Reports</h2>
+<p>Create detailed reports about your shipments.</p>

--- a/src/app/pages/help/tracking-tools/tracking-reports/tracking-reports.component.scss
+++ b/src/app/pages/help/tracking-tools/tracking-reports/tracking-reports.component.scss
@@ -1,0 +1,3 @@
+h2 {
+  margin-bottom: 1rem;
+}

--- a/src/app/pages/help/tracking-tools/tracking-reports/tracking-reports.component.ts
+++ b/src/app/pages/help/tracking-tools/tracking-reports/tracking-reports.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-tracking-reports',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './tracking-reports.component.html',
+  styleUrls: ['./tracking-reports.component.scss']
+})
+export class TrackingReportsComponent {}

--- a/src/app/pages/help/tracking-tools/tracking-tools.component.ts
+++ b/src/app/pages/help/tracking-tools/tracking-tools.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { NotificationService } from '../../../shared/services/notification.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-tracking-tools',
@@ -10,29 +10,29 @@ import { NotificationService } from '../../../shared/services/notification.servi
   styleUrls: ['./tracking-tools.component.scss']
 })
 export class TrackingToolsComponent {
-  constructor(private notificationService: NotificationService) {}
+  constructor(private router: Router) {}
 
   openBulkTracking() {
-    this.notificationService.show('Opening bulk tracking tool...', 'info');
+    this.router.navigate(['/help/bulk-tracking']);
   }
 
   openMobileApp() {
-    this.notificationService.show('Opening mobile app download page...', 'info');
+    this.router.navigate(['/help/mobile-app']);
   }
 
   openAPI() {
-    this.notificationService.show('Opening API documentation...', 'info');
+    this.router.navigate(['/help/api-access']);
   }
 
   openEmailTracking() {
-    this.notificationService.show('Opening email tracking setup...', 'info');
+    this.router.navigate(['/help/email-tracking']);
   }
 
   openReports() {
-    this.notificationService.show('Opening tracking reports...', 'info');
+    this.router.navigate(['/help/tracking-reports']);
   }
 
   openIntegrations() {
-    this.notificationService.show('Opening integration options...', 'info');
+    this.router.navigate(['/help/integrations']);
   }
-} 
+}


### PR DESCRIPTION
## Summary
- create standalone components for individual help guides and tools
- expand help routes to include new pages
- navigate to these pages from tracking advice and tools sections

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf39b7b90832e9215aae649ae854d