### PR TITLE
Add Angular Material to help center

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@angular/compiler": "^16.0.0",
         "@angular/core": "^16.0.0",
         "@angular/forms": "^16.2.12",
+        "@angular/material": "^16.2.12",
         "@angular/platform-browser": "^16.0.0",
         "@angular/platform-browser-dynamic": "^16.0.0",
         "@angular/router": "^16.0.0",
@@ -586,6 +587,24 @@
         "@angular/core": "16.2.12"
       }
     },
+    "node_modules/@angular/cdk": {
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-16.2.12.tgz",
+      "integrity": "sha512-wT8/265zm2WKY0BDaRoYbrAT4kadrmejTRLjuimQIEUKnw4vBsJMWCwQkpFo3s6zr6eznGqYVAFb8KKPVLKGBg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "optionalDependencies": {
+        "parse5": "^7.1.2"
+      },
+      "peerDependencies": {
+        "@angular/common": "^16.0.0 || ^17.0.0",
+        "@angular/core": "^16.0.0 || ^17.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
     "node_modules/@angular/cli": {
       "version": "16.0.6",
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-16.0.6.tgz",
@@ -854,6 +873,71 @@
         "@angular/common": "16.2.12",
         "@angular/core": "16.2.12",
         "@angular/platform-browser": "16.2.12",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/material": {
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-16.2.12.tgz",
+      "integrity": "sha512-k1DGRfP1mMmhg/nLJjZBOPzX3SyAjgbRBY2KauKOV8OFCXJGoMn/oLgMBh+qB1WugzIna/31dBV8ruHD3Uvp2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/auto-init": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/banner": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/card": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/checkbox": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/chips": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/circular-progress": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/data-table": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dialog": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/drawer": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/fab": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/floating-label": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/form-field": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/icon-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/image-list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/layout-grid": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/line-ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/linear-progress": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu-surface": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/notched-outline": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/radio": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/segmented-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/select": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/slider": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/snackbar": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/switch": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-bar": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-scroller": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/textfield": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tooltip": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/top-app-bar": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": "^16.0.0 || ^17.0.0",
+        "@angular/cdk": "16.2.12",
+        "@angular/common": "^16.0.0 || ^17.0.0",
+        "@angular/core": "^16.0.0 || ^17.0.0",
+        "@angular/forms": "^16.0.0 || ^17.0.0",
+        "@angular/platform-browser": "^16.0.0 || ^17.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -3466,6 +3550,808 @@
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@material/animation": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-leRf+BcZTfC/iSigLXnYgcHAGvFVQveoJT5+2PIRdyPI/bIG7hhciRgacHRsCKC0sGya81dDblLgdkjSUemYLw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/auto-init": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/auto-init/-/auto-init-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-uxzDq7q3c0Bu1pAsMugc1Ik9ftQYQqZY+5e2ybNplT8gTImJhNt4M2mMiMHbMANk2l3UgICmUyRSomgPBWCPIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/banner": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/banner/-/banner-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-SHeVoidCUFVhXANN6MNWxK9SZoTSgpIP8GZB7kAl52BywLxtV+FirTtLXkg/8RUkxZRyRWl7HvQ0ZFZa7QQAyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/base": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Fc3vGuOf+duGo22HTRP6dHdc+MUe0VqQfWOuKrn/wXKD62m0QQR2TqJd3rRhCumH557T5QUyheW943M3E+IGfg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/button": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/button/-/button-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-3AQgwrPZCTWHDJvwgKq7Cj+BurQ4wTjDdGL+FEnIGUAjJDskwi1yzx5tW2Wf/NxIi7IoPFyOY3UB41jwMiOrnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/card": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/card/-/card-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-nPlhiWvbLmooTnBmV5gmzB0eLWSgLKsSRBYAbIBmO76Okgz1y+fQNLag+lpm/TDaHVsn5fmQJH8e0zIg0rYsQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/checkbox": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/checkbox/-/checkbox-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-4tpNnO1L0IppoMF3oeQn8F17t2n0WHB0D7mdJK9rhrujen/fLbekkIC82APB3fdGtLGg3qeNqDqPsJm1YnmrwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/chips": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/chips/-/chips-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-fqHKvE5bSWK0bXVkf57MWxZtytGqYBZvvHIOs4JI9HPHEhaJy4CpSw562BEtbm3yFxxALoQknvPW2KYzvADnmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/checkbox": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "safevalues": "^0.3.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/circular-progress": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/circular-progress/-/circular-progress-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Lxe8BGAxQwCQqrLhrYrIP0Uok10h7aYS3RBXP41ph+5GmwJd5zdyE2t93qm2dyThvU6qKuXw9726Dtq/N+wvZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/progress-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/data-table": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/data-table/-/data-table-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-j/7qplT9+sUpfe4pyWhPbl01qJA+OoNAG3VMJruBBR461ZBKyTi7ssKH9yksFGZ8eCEPkOsk/+kDxsiZvRWkeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/checkbox": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/icon-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/linear-progress": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/select": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/density": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/density/-/density-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Zt3u07fXrBWLW06Tl5fgvjicxNQMkFdawLyNTzZ5TvbXfVkErILLePwwGaw8LNcvzqJP6ABLA8jiR+sKNoJQCg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/dialog": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/dialog/-/dialog-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-o+9a/fmwJ9+gY3Z/uhj/PMVJDq7it1NTWKJn2GwAKdB+fDkT4hb9qEdcxMPyvJJ5ups+XiKZo03+tZrD+38c1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/icon-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/dom": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-ly78R7aoCJtundSUu0UROU+5pQD5Piae0Y1MkN6bs0724azeazX1KeXFeaf06JOXnlr5/41ol+fSUPowjoqnOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/drawer": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/drawer/-/drawer-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-PFL4cEFnt7VTxDsuspFVNhsFDYyumjU0VWfj3PWB7XudsEfQ3lo85D3HCEtTTbRsCainGN8bgYNDNafLBqiigw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/elevation": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Ro+Pk8jFuap+T0B0shA3xI1hs2b89dNQ2EIPCNjNMp87emHKAzJfhKb7EZGIwv3+gFLlVaLyIVkb94I89KLsyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/fab": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/fab/-/fab-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-dvU0KWMRglwJEQwmQtFAmJcAjzg9VFF6Aqj78bJYu/DAIGFJ1VTTTSgoXM/XCm1YyQEZ7kZRvxBO37CH54rSDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/feature-targeting": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-wkDjVcoVEYYaJvun28IXdln/foLgPD7n9ZC9TY76GErGCwTq+HWpU6wBAAk+ePmpRFDayw4vI4wBlaWGxLtysQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/floating-label": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/floating-label/-/floating-label-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-bUWPtXzZITOD/2mkvLkEPO1ngDWmb74y0Kgbz6llHLOQBtycyJIpuoQJ1q2Ez0NM/tFLwPphhAgRqmL3YQ/Kzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/focus-ring": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/focus-ring/-/focus-ring-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-cZHThVose3GvAlJzpJoBI1iqL6d1/Jj9hXrR+r8Mwtb1hBIUEG3hxfsRd4vGREuzROPlf0OgNf/V+YHoSwgR5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0"
+      }
+    },
+    "node_modules/@material/form-field": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/form-field/-/form-field-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-+JFXy5X44Gue1CbZZAQ6YejnI203lebYwL0i6k0ylDpWHEOdD5xkF2PyHR28r9/65Ebcbwbff6q7kI1SGoT7MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/icon-button": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/icon-button/-/icon-button-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-1a0MHgyIwOs4RzxrVljsqSizGYFlM1zY2AZaLDsgT4G3kzsplTx8HZQ022GpUCjAygW+WLvg4z1qAhQHvsbqlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/image-list": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/image-list/-/image-list-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-WKWmiYap2iu4QdqmeUSliLlN4O2Ueqa0OuVAYHn/TCzmQ2xmnhZ1pvDLbs6TplpOmlki7vFfe+aSt5SU9gwfOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/layout-grid": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/layout-grid/-/layout-grid-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-5GqmT6oTZhUGWIb+CLD0ZNyDyTiJsr/rm9oRIi3+vCujACwxFkON9tzBlZohdtFS16nuzUusthN6Jt9UrJcN6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/line-ripple": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/line-ripple/-/line-ripple-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-8S30WXEuUdgDdBulzUDlPXD6qMzwCX9SxYb5mGDYLwl199cpSGdXHtGgEcCjokvnpLhdZhcT1Dsxeo1g2Evh5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/linear-progress": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/linear-progress/-/linear-progress-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-6EJpjrz6aoH2/gXLg9iMe0yF2C42hpQyZoHpmcgTLKeci85ktDvJIjwup8tnk8ULQyFiGiIrhXw2v2RSsiFjvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/progress-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/list": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/list/-/list-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-TQ1ppqiCMQj/P7bGD4edbIIv4goczZUoiUAaPq/feb1dflvrFMzYqJ7tQRRCyBL8nRhJoI2x99tk8Q2RXvlGUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/menu": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/menu/-/menu-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-IlAh61xzrzxXs38QZlt74UYt8J431zGznSzDtB1Fqs6YFNd11QPKoiRXn1J2Qu/lUxbFV7i8NBKMCKtia0n6/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu-surface": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/menu-surface": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/menu-surface/-/menu-surface-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-dMtSPN+olTWE+08M5qe4ea1IZOhVryYqzK0Gyb2u1G75rSArUxCOB5rr6OC/ST3Mq3RS6zGuYo7srZt4534K9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/notched-outline": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/notched-outline/-/notched-outline-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-WuurMg44xexkvLTBTnsO0A+qnzFjpcPdvgWBGstBepYozsvSF9zJGdb1x7Zv1MmqbpYh/Ohnuxtb/Y3jOh6irg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/floating-label": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/progress-indicator": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/progress-indicator/-/progress-indicator-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-uOnsvqw5F2fkeTnTl4MrYzjI7KCLmmLyZaM0cgLNuLsWVlddQE+SGMl28tENx7DUK3HebWq0FxCP8f25LuDD+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/radio": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/radio/-/radio-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-ehzOK+U1IxQN+OQjgD2lsnf1t7t7RAwQzeO6Czkiuid29ookYbQynWuLWk7NW8H8ohl7lnmfqTP1xSNkkL/F0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/ripple": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-JfLW+g3GMVDv4cruQ19+HUxpKVdWCldFlIPw1UYezz2h3WTNDy05S3uP2zUdXzZ01C3dkBFviv4nqZ0GCT16MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/rtl": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-SkKLNLFp5QtG7/JEFg9R92qq4MzTcZ5As6sWbH7rRg6ahTHoJEuqE+pOb9Vrtbj84k5gtX+vCYPvCILtSlr2uw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/segmented-button": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/segmented-button/-/segmented-button-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-YDwkCWP9l5mIZJ7pZJZ2hMDxfBlIGVJ+deNzr8O+Z7/xC5LGXbl4R5aPtUVHygvXAXxpf5096ZD+dSXzYzvWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/select": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/select/-/select-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-unfOWVf7T0sixVG+3k3RTuATfzqvCF6QAzA6J9rlCh/Tq4HuIBNDdV4z19IVu4zwmgWYxY0iSvqWUvdJJYwakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/floating-label": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/line-ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu-surface": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/notched-outline": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/shape": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/shape/-/shape-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Dsvr771ZKC46ODzoixLdGwlLEQLfxfLrtnRojXABoZf5G3o9KtJU+J+5Ld5aa960OAsCzzANuaub4iR88b1guA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/slider": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/slider/-/slider-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-3AEu+7PwW4DSNLndue47dh2u7ga4hDJRYmuu7wnJCIWJBnLCkp6C92kNc4Rj5iQY2ftJio5aj1gqryluh5tlYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/snackbar": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/snackbar/-/snackbar-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-TwwQSYxfGK6mc03/rdDamycND6o+1p61WNd7ElZv1F1CLxB4ihRjbCoH7Qo+oVDaP8CTpjeclka+24RLhQq0mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/icon-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/switch": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/switch/-/switch-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-OjUjtT0kRz1ASAsOS+dNzwMwvsjmqy5edK57692qmrP6bL4GblFfBDoiNJ6t0AN4OaKcmL5Hy/xNrTdOZW7Qqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "safevalues": "^0.3.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tab/-/tab-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-s/L9otAwn/pZwVQZBRQJmPqYeNbjoEbzbjMpDQf/VBG/6dJ+aP03ilIBEkqo8NVnCoChqcdtVCoDNRtbU+yp6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab-bar": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-bar/-/tab-bar-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Xmtq0wJGfu5k+zQeFeNsr4bUKv7L+feCmUp/gsapJ655LQKMXOUQZtSv9ZqWOfrCMy55hoF1CzGFV+oN3tyWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-scroller": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab-indicator": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-indicator/-/tab-indicator-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-despCJYi1GrDDq7F2hvLQkObHnSLZPPDxnOzU16zJ6FNYvIdszgfzn2HgAZ6pl5hLOexQ8cla6cAqjTDuaJBhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab-scroller": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-scroller/-/tab-scroller-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-QWHG/EWxirj4V9u2IHz+OSY9XCWrnNrPnNgEufxAJVUKV/A8ma1DYeFSQqxhX709R8wKGdycJksg0Flkl7Gq7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/textfield": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/textfield/-/textfield-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-R3qRex9kCaZIAK8DuxPnVC42R0OaW7AB7fsFknDKeTeVQvRcbnV8E+iWSdqTiGdsi6QQHifX8idUrXw+O45zPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/floating-label": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/line-ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/notched-outline": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/theme": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-CpUwXGE0dbhxQ45Hu9r9wbJtO/MAlv5ER4tBHA9tp/K+SU+lDgurBE2touFMg5INmdfVNtdumxb0nPPLaNQcUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tokens": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-nbEuGj05txWz6ZMUanpM47SaAD7soyjKILR+XwDell9Zg3bGhsnexCNXPEz2fD+YgomS+jM5XmIcaJJHg/H93Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0"
+      }
+    },
+    "node_modules/@material/tooltip": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tooltip/-/tooltip-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-UzuXp0b9NuWuYLYpPguxrjbJnCmT/Cco8CkjI/6JajxaeA3o2XEBbQfRMTq8PTafuBjCHTc0b0mQY7rtxUp1Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "safevalues": "^0.3.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/top-app-bar": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/top-app-bar/-/top-app-bar-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-vJWjsvqtdSD5+yQ/9vgoBtBSCvPJ5uF/DVssv8Hdhgs1PYaAcODUi77kdi0+sy/TaWyOsTkQixqmwnFS16zesA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/touch-target": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-AqYh9fjt+tv4ZE0C6MeYHblS2H+XwLbDl2mtyrK0DOEnCVQk5/l5ImKDfhrUdFWHvS4a5nBM4AA+sa7KaroLoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/typography": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-CKsG1zyv34AKPNyZC8olER2OdPII64iR2SzQjpqh1UUvmIFiMPk23LvQ1OnC5aCB14pOXzmVgvJt31r9eNdZ6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
     },
     "node_modules/@ngtools/webpack": {
       "version": "16.2.16",
@@ -10651,7 +11537,7 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -10692,7 +11578,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -11754,6 +12640,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/safevalues": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/safevalues/-/safevalues-0.3.4.tgz",
+      "integrity": "sha512-LRneZZRXNgjzwG4bDQdOTSbze3fHm1EAKN/8bePxnlEZiBmkYEDggaHbuvHI9/hoqHbGfsEA7tWS9GhYHZBBsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/sass": {
       "version": "1.64.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@angular/compiler": "^16.0.0",
     "@angular/core": "^16.0.0",
     "@angular/forms": "^16.2.12",
+    "@angular/material": "^16.2.12",
     "@angular/platform-browser": "^16.0.0",
     "@angular/platform-browser-dynamic": "^16.0.0",
     "@angular/router": "^16.0.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormsModule } from '@angular/forms';
 
 import { AppRoutingModule } from './app-routing.module';
@@ -24,6 +25,7 @@ import { NotificationComponent } from './shared/components/notification/notifica
   ],
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
     AppRoutingModule,
     FormsModule
   ],

--- a/src/app/pages/help/contact-us/contact-us.component.html
+++ b/src/app/pages/help/contact-us/contact-us.component.html
@@ -47,67 +47,42 @@
         <p>Fill out the form below and we'll get back to you as soon as possible.</p>
       </div>
 
-      <div class="form-group">
-        <label for="name">Name *</label>
-        <input 
-          type="text" 
-          id="name" 
-          formControlName="name"
-          [class.error]="contactForm.get('name')?.invalid && contactForm.get('name')?.touched"
-        >
-        <span class="error-message" *ngIf="contactForm.get('name')?.invalid && contactForm.get('name')?.touched">
+      <mat-form-field appearance="fill" class="w-100">
+        <mat-label>Name *</mat-label>
+        <input matInput id="name" formControlName="name">
+        <mat-error *ngIf="contactForm.get('name')?.invalid && contactForm.get('name')?.touched">
           {{ getErrorMessage('name') }}
-        </span>
-      </div>
+        </mat-error>
+      </mat-form-field>
 
-      <div class="form-group">
-        <label for="email">Email *</label>
-        <input 
-          type="email" 
-          id="email" 
-          formControlName="email"
-          [class.error]="contactForm.get('email')?.invalid && contactForm.get('email')?.touched"
-        >
-        <span class="error-message" *ngIf="contactForm.get('email')?.invalid && contactForm.get('email')?.touched">
+      <mat-form-field appearance="fill" class="w-100">
+        <mat-label>Email *</mat-label>
+        <input matInput type="email" id="email" formControlName="email">
+        <mat-error *ngIf="contactForm.get('email')?.invalid && contactForm.get('email')?.touched">
           {{ getErrorMessage('email') }}
-        </span>
-      </div>
+        </mat-error>
+      </mat-form-field>
 
-      <div class="form-group">
-        <label for="subject">Subject *</label>
-        <input 
-          type="text" 
-          id="subject" 
-          formControlName="subject"
-          [class.error]="contactForm.get('subject')?.invalid && contactForm.get('subject')?.touched"
-        >
-        <span class="error-message" *ngIf="contactForm.get('subject')?.invalid && contactForm.get('subject')?.touched">
+      <mat-form-field appearance="fill" class="w-100">
+        <mat-label>Subject *</mat-label>
+        <input matInput id="subject" formControlName="subject">
+        <mat-error *ngIf="contactForm.get('subject')?.invalid && contactForm.get('subject')?.touched">
           {{ getErrorMessage('subject') }}
-        </span>
-      </div>
+        </mat-error>
+      </mat-form-field>
 
-      <div class="form-group">
-        <label for="trackingNumber">Tracking Number (Optional)</label>
-        <input 
-          type="text" 
-          id="trackingNumber" 
-          formControlName="trackingNumber"
-          placeholder="e.g., GLX123456789"
-        >
-      </div>
+      <mat-form-field appearance="fill" class="w-100">
+        <mat-label>Tracking Number (Optional)</mat-label>
+        <input matInput id="trackingNumber" formControlName="trackingNumber" placeholder="e.g., GLX123456789">
+      </mat-form-field>
 
-      <div class="form-group">
-        <label for="message">Message *</label>
-        <textarea 
-          id="message" 
-          formControlName="message"
-          rows="5"
-          [class.error]="contactForm.get('message')?.invalid && contactForm.get('message')?.touched"
-        ></textarea>
-        <span class="error-message" *ngIf="contactForm.get('message')?.invalid && contactForm.get('message')?.touched">
+      <mat-form-field appearance="fill" class="w-100">
+        <mat-label>Message *</mat-label>
+        <textarea matInput id="message" formControlName="message" rows="5"></textarea>
+        <mat-error *ngIf="contactForm.get('message')?.invalid && contactForm.get('message')?.touched">
           {{ getErrorMessage('message') }}
-        </span>
-      </div>
+        </mat-error>
+      </mat-form-field>
 
       <div class="form-group">
         <label for="attachments">Attachments</label>
@@ -128,10 +103,10 @@
       </div>
 
       <div class="form-actions">
-        <button type="button" class="btn-secondary" (click)="selectedOption = null">
+        <button mat-stroked-button type="button" (click)="selectedOption = null">
           Cancel
         </button>
-        <button type="submit" class="btn-primary" [disabled]="contactForm.invalid">
+        <button mat-raised-button color="primary" type="submit" [disabled]="contactForm.invalid">
           Send Message
           <i class="fas fa-paper-plane" aria-hidden="true"></i>
         </button>

--- a/src/app/pages/help/contact-us/contact-us.component.ts
+++ b/src/app/pages/help/contact-us/contact-us.component.ts
@@ -1,6 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
 import { NotificationService } from '../../../shared/services/notification.service';
 
 interface ContactOption {
@@ -15,7 +18,14 @@ interface ContactOption {
 @Component({
   selector: 'app-contact-us',
   standalone: true,
-  imports: [CommonModule, FormsModule, ReactiveFormsModule],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule
+  ],
   templateUrl: './contact-us.component.html',
   styleUrls: ['./contact-us.component.scss']
 })

--- a/src/app/pages/help/faqs/faqs.component.html
+++ b/src/app/pages/help/faqs/faqs.component.html
@@ -2,13 +2,10 @@
   <!-- Search and Filter Section -->
   <div class="search-filter">
     <div class="search-box">
-      <i class="fas fa-search" aria-hidden="true"></i>
-      <input 
-        type="text" 
-        [(ngModel)]="searchQuery" 
-        placeholder="Search FAQs..."
-        aria-label="Search frequently asked questions"
-      >
+      <mat-form-field appearance="outline" class="w-100">
+        <mat-label>Search FAQs</mat-label>
+        <input matInput [(ngModel)]="searchQuery" placeholder="Search FAQs..." aria-label="Search frequently asked questions">
+      </mat-form-field>
     </div>
     <div class="category-filter">
       <button 

--- a/src/app/pages/help/faqs/faqs.component.scss
+++ b/src/app/pages/help/faqs/faqs.component.scss
@@ -10,36 +10,7 @@
 }
 
 .search-box {
-  position: relative;
   margin-bottom: 20px;
-
-  i {
-    position: absolute;
-    left: 16px;
-    top: 50%;
-    transform: translateY(-50%);
-    color: var(--gray-400);
-    font-size: 18px;
-  }
-
-  input {
-    width: 100%;
-    padding: 16px 16px 16px 48px;
-    border: 2px solid var(--gray-200);
-    border-radius: var(--border-radius);
-    font-size: 16px;
-    transition: var(--transition);
-
-    &:focus {
-      outline: none;
-      border-color: var(--primary-purple);
-      box-shadow: 0 0 0 3px rgba(77, 20, 140, 0.1);
-    }
-
-    &::placeholder {
-      color: var(--gray-400);
-    }
-  }
 }
 
 .category-filter {

--- a/src/app/pages/help/faqs/faqs.component.ts
+++ b/src/app/pages/help/faqs/faqs.component.ts
@@ -1,6 +1,9 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
 
 interface FAQ {
   question: string;
@@ -12,7 +15,13 @@ interface FAQ {
 @Component({
   selector: 'app-faqs',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule
+  ],
   templateUrl: './faqs.component.html',
   styleUrls: ['./faqs.component.scss']
 })

--- a/src/app/pages/help/help.component.html
+++ b/src/app/pages/help/help.component.html
@@ -30,19 +30,18 @@
         <section class="quick-search animate-fade-in" aria-labelledby="search-title">
             <div class="search-card">
                 <form class="search-form" (ngSubmit)="quickTrack()" role="search" aria-label="Quick package tracking">
-                    <div class="form-group">
-                        <label for="quick-tracking" class="form-label">Quick Track Your Package</label>
-                        <input 
-                            type="text" 
-                            id="quick-tracking" 
-                            class="form-input" 
+                    <mat-form-field appearance="outline" class="w-100">
+                        <mat-label>Quick Track Your Package</mat-label>
+                        <input
+                            matInput
+                            type="text"
+                            id="quick-tracking"
                             placeholder="Enter tracking number (e.g., GLX123456789)"
                             aria-describedby="tracking-help"
                             [(ngModel)]="trackingNumber"
-                            name="trackingNumber"
-                        >
-                    </div>
-                    <button type="submit" class="btn btn-primary search-btn">
+                            name="trackingNumber">
+                    </mat-form-field>
+                    <button mat-raised-button color="primary" type="submit" class="search-btn">
                         <i class="fas fa-search" aria-hidden="true"></i>
                         Track Now
                     </button>
@@ -52,63 +51,37 @@
         </section>
 
         <!-- ===== NAVIGATION TABS ===== -->
-        <nav class="nav-tabs animate-fade-in" role="tablist" aria-label="Help categories">
-            <button 
-                class="nav-tab" 
-                [class.active]="currentTab === 'tracking-advice'"
-                role="tab" 
-                [attr.aria-selected]="currentTab === 'tracking-advice'"
-                aria-controls="tracking-advice" 
-                id="advice-tab" 
-                (click)="switchTab('tracking-advice')"
-            >
-                <i class="fas fa-lightbulb" aria-hidden="true"></i>
-                Tracking Advice
-            </button>
-            <button 
-                class="nav-tab" 
-                [class.active]="currentTab === 'tracking-tools'"
-                role="tab" 
-                [attr.aria-selected]="currentTab === 'tracking-tools'"
-                aria-controls="tracking-tools" 
-                id="tools-tab" 
-                (click)="switchTab('tracking-tools')"
-            >
-                <i class="fas fa-tools" aria-hidden="true"></i>
-                Tracking Tools
-            </button>
-            <button 
-                class="nav-tab" 
-                [class.active]="currentTab === 'faqs'"
-                role="tab" 
-                [attr.aria-selected]="currentTab === 'faqs'"
-                aria-controls="faqs" 
-                id="faqs-tab" 
-                (click)="switchTab('faqs')"
-            >
-                <i class="fas fa-question-circle" aria-hidden="true"></i>
-                FAQs
-            </button>
-            <button 
-                class="nav-tab" 
-                [class.active]="currentTab === 'contact-us'"
-                role="tab" 
-                [attr.aria-selected]="currentTab === 'contact-us'"
-                aria-controls="contact-us" 
-                id="contact-tab" 
-                (click)="switchTab('contact-us')"
-            >
-                <i class="fas fa-headset" aria-hidden="true"></i>
-                Contact Us
-            </button>
-        </nav>
-
-        <!-- ===== TAB CONTENT ===== -->
-        <div [ngSwitch]="currentTab">
-            <app-tracking-advice *ngSwitchCase="'tracking-advice'" class="tab-content active"></app-tracking-advice>
-            <app-tracking-tools *ngSwitchCase="'tracking-tools'" class="tab-content active"></app-tracking-tools>
-            <app-faqs *ngSwitchCase="'faqs'" class="tab-content active"></app-faqs>
-            <app-contact-us *ngSwitchCase="'contact-us'" class="tab-content active"></app-contact-us>
-        </div>
+        <mat-tab-group class="nav-tabs animate-fade-in custom-tabs"
+                        [selectedIndex]="tabLabels.indexOf(currentTab)"
+                        (selectedTabChange)="switchTab(tabLabels[$event.index])">
+            <mat-tab>
+                <ng-template mat-tab-label>
+                    <i class="fas fa-lightbulb" aria-hidden="true"></i>
+                    Tracking Advice
+                </ng-template>
+                <app-tracking-advice class="tab-content"></app-tracking-advice>
+            </mat-tab>
+            <mat-tab>
+                <ng-template mat-tab-label>
+                    <i class="fas fa-tools" aria-hidden="true"></i>
+                    Tracking Tools
+                </ng-template>
+                <app-tracking-tools class="tab-content"></app-tracking-tools>
+            </mat-tab>
+            <mat-tab>
+                <ng-template mat-tab-label>
+                    <i class="fas fa-question-circle" aria-hidden="true"></i>
+                    FAQs
+                </ng-template>
+                <app-faqs class="tab-content"></app-faqs>
+            </mat-tab>
+            <mat-tab>
+                <ng-template mat-tab-label>
+                    <i class="fas fa-headset" aria-hidden="true"></i>
+                    Contact Us
+                </ng-template>
+                <app-contact-us class="tab-content"></app-contact-us>
+            </mat-tab>
+        </mat-tab-group>
     </div>
 </main> 

--- a/src/app/pages/help/help.component.scss
+++ b/src/app/pages/help/help.component.scss
@@ -183,48 +183,15 @@
   }
 }
 
-// Navigation Tabs
-.nav-tabs {
-  background: var(--white);
-  border-radius: var(--border-radius-lg);
-  padding: 8px;
+// Material Navigation Tabs
+.mat-tab-group.custom-tabs {
   margin-bottom: 40px;
-  box-shadow: var(--shadow);
-  border: 1px solid var(--gray-200);
-  display: flex;
-  justify-content: center;
-  overflow-x: auto;
 }
 
-.nav-tab {
-  flex: 1;
-  padding: 16px 24px;
-  border: none;
-  background: transparent;
-  color: var(--gray-600);
-  font-size: 15px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: var(--transition);
-  border-radius: var(--border-radius);
-  white-space: nowrap;
-  min-width: 160px;
+.mat-tab-label {
   display: flex;
   align-items: center;
-  justify-content: center;
   gap: 8px;
-
-  &:hover {
-    background: var(--gray-50);
-    color: var(--gray-900);
-  }
-
-  &.active {
-    background: var(--primary-purple);
-    color: var(--white);
-    font-weight: 600;
-    box-shadow: var(--shadow);
-  }
 }
 
 // Tab Content
@@ -283,14 +250,9 @@
     flex-direction: column;
   }
 
-  .nav-tabs {
+  .mat-tab-group.custom-tabs {
     flex-direction: column;
     gap: 4px;
-  }
-
-  .nav-tab {
-    min-width: auto;
-    text-align: center;
   }
 }
 

--- a/src/app/pages/help/help.component.ts
+++ b/src/app/pages/help/help.component.ts
@@ -6,6 +6,10 @@ import { NotificationService } from '../../shared/services/notification.service'
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { TrackingAdviceComponent } from './tracking-advice/tracking-advice.component';
 import { TrackingToolsComponent } from './tracking-tools/tracking-tools.component';
 import { FaqsComponent } from './faqs/faqs.component';
@@ -18,6 +22,10 @@ import { ContactUsComponent } from './contact-us/contact-us.component';
     CommonModule,
     FormsModule,
     RouterModule,
+    MatTabsModule,
+    MatInputModule,
+    MatButtonModule,
+    MatFormFieldModule,
     TrackingAdviceComponent,
     TrackingToolsComponent,
     FaqsComponent,
@@ -29,6 +37,7 @@ import { ContactUsComponent } from './contact-us/contact-us.component';
 export class HelpComponent implements OnInit {
   currentTab: string = 'tracking-advice';
   trackingNumber: string = '';
+  tabLabels: string[] = ['tracking-advice', 'tracking-tools', 'faqs', 'contact-us'];
 
   constructor(
     private titleService: Title,

--- a/src/app/pages/help/help.module.ts
+++ b/src/app/pages/help/help.module.ts
@@ -2,6 +2,11 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
 
 import { HelpComponent } from './help.component';
 import { TrackingAdviceComponent } from './tracking-advice/tracking-advice.component';
@@ -22,7 +27,12 @@ import { HELP_ROUTES } from './help.routes';
     CommonModule,
     FormsModule,
     ReactiveFormsModule,
+    BrowserAnimationsModule,
+    MatTabsModule,
+    MatInputModule,
+    MatButtonModule,
+    MatFormFieldModule,
     RouterModule.forChild(HELP_ROUTES)
   ]
 })
-export class HelpModule { } 
+export class HelpModule { }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,6 +1,23 @@
 /* You can add global styles to this file, and also import other style files */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 @import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css');
+@use '@angular/material' as mat;
+
+@include mat.core();
+
+$primary-palette: mat.define-palette(mat.$deep-purple-palette);
+$accent-palette: mat.define-palette(mat.$pink-palette, A200, A100, A400);
+$warn-palette: mat.define-palette(mat.$red-palette);
+
+$theme: mat.define-light-theme((
+  color: (
+    primary: $primary-palette,
+    accent: $accent-palette,
+    warn: $warn-palette,
+  )
+));
+
+@include mat.all-component-themes($theme);
 
 /* Variables CSS globales */
 :root {


### PR DESCRIPTION
## Summary
- install `@angular/material`
- import material modules in help components
- migrate help center UI to use Material tabs, inputs, and buttons
- enable Material theming

## Testing
- `npm test` *(fails: Cannot find module './lib/source-map-generator')*

------
https://chatgpt.com/codex/tasks/task_e_684cf39dec00832ea1e8d38ba2620431