### PR TITLE
Update help link anchors

### DIFF
--- a/src/app/features/tracking/components/all-tracking/all-tracking.component.html
+++ b/src/app/features/tracking/components/all-tracking/all-tracking.component.html
@@ -86,7 +86,7 @@
             </button>
           </div>
 
-          <a href="#" class="need-help">NEED HELP?</a>
+          <a routerLink="/help" class="need-help">NEED HELP?</a>
           
           <div style="text-align: center;">
             <button 
@@ -139,7 +139,7 @@
             </select>
           </div>
 
-          <a href="#" class="need-help">NEED HELP?</a>
+          <a routerLink="/help" class="need-help">NEED HELP?</a>
           
           <div style="text-align: center;">
             <button 
@@ -191,7 +191,7 @@
             <div class="form-help">Please enter the ship date if the package was shipped more than 14 days ago.</div>
           </div>
 
-          <a href="#" class="need-help">NEED HELP?</a>
+          <a routerLink="/help" class="need-help">NEED HELP?</a>
           
           <div style="text-align: center;">
             <button 


### PR DESCRIPTION
## Summary
- link to help page via routerLink instead of `href="#"` anchors

## Testing
- `npm install`
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_684cf3996b08832e9910f0e4d3b2f53b