### PR TITLE
Add unit tests for help components

### DIFF
--- a/src/app/pages/help/contact-us/contact-us.component.spec.ts
+++ b/src/app/pages/help/contact-us/contact-us.component.spec.ts
@@ -1,0 +1,56 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ContactUsComponent } from './contact-us.component';
+import { NotificationService } from '../../../shared/services/notification.service';
+
+class MockNotificationService {
+  success = jasmine.createSpy('success');
+  error = jasmine.createSpy('error');
+}
+
+describe('ContactUsComponent', () => {
+  let component: ContactUsComponent;
+  let fixture: ComponentFixture<ContactUsComponent>;
+  let notif: MockNotificationService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ContactUsComponent],
+      providers: [{ provide: NotificationService, useClass: MockNotificationService }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ContactUsComponent);
+    component = fixture.componentInstance;
+    notif = TestBed.inject(NotificationService) as any;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should error on invalid form submit', () => {
+    component.onSubmit();
+    expect(notif.error).toHaveBeenCalled();
+  });
+
+  it('should submit valid form', () => {
+    component.contactForm.setValue({
+      name: 'John',
+      email: 'john@example.com',
+      subject: 'Help',
+      message: 'Hello world!',
+      trackingNumber: '',
+      attachments: []
+    });
+    component.onSubmit();
+    expect(notif.success).toHaveBeenCalled();
+    expect(component.selectedOption).toBeNull();
+  });
+
+  it('should return error message', () => {
+    const control = component.contactForm.get('name');
+    control?.setValue('');
+    control?.markAsTouched();
+    expect(component.getErrorMessage('name')).toBe('Name is required');
+  });
+});

--- a/src/app/pages/help/faqs/faqs.component.spec.ts
+++ b/src/app/pages/help/faqs/faqs.component.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FaqsComponent } from './faqs.component';
+
+describe('FaqsComponent', () => {
+  let component: FaqsComponent;
+  let fixture: ComponentFixture<FaqsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FaqsComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FaqsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should toggle faq', () => {
+    const faq = component.faqs[0];
+    expect(faq.isOpen).toBeFalse();
+    component.toggleFAQ(faq);
+    expect(faq.isOpen).toBeTrue();
+  });
+
+  it('should filter by category and search', () => {
+    component.selectedCategory = 'tracking';
+    component.searchQuery = 'multiple';
+    const filtered = component.filterFAQs();
+    expect(filtered.length).toBe(1);
+    expect(filtered[0].question).toContain('multiple');
+  });
+});

--- a/src/app/pages/help/help.component.spec.ts
+++ b/src/app/pages/help/help.component.spec.ts
@@ -1,0 +1,75 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { Router, ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Title } from '@angular/platform-browser';
+import { Subject } from 'rxjs';
+
+import { HelpComponent } from './help.component';
+import { NotificationService } from '../../shared/services/notification.service';
+
+class MockNotificationService {
+  show = jasmine.createSpy('show');
+  success = jasmine.createSpy('success');
+  error = jasmine.createSpy('error');
+  warning = jasmine.createSpy('warning');
+  info = jasmine.createSpy('info');
+}
+
+describe('HelpComponent', () => {
+  let component: HelpComponent;
+  let fixture: ComponentFixture<HelpComponent>;
+  let router: Router;
+  let notif: MockNotificationService;
+
+  beforeEach(async () => {
+    const events$ = new Subject();
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule, HelpComponent],
+      providers: [
+        { provide: NotificationService, useClass: MockNotificationService },
+        { provide: ActivatedRoute, useValue: { snapshot: { fragment: null }, events: events$ } },
+        { provide: Title, useValue: { setTitle: () => {} } }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HelpComponent);
+    component = fixture.componentInstance;
+    router = TestBed.inject(Router);
+    notif = TestBed.inject(NotificationService) as any;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should switch tab and update fragment', () => {
+    const navigateSpy = spyOn(router, 'navigate');
+    component.switchTab('faqs');
+
+    expect(component.currentTab).toBe('faqs');
+    expect(navigateSpy).toHaveBeenCalledWith([], {
+      fragment: 'faq',
+      relativeTo: TestBed.inject(ActivatedRoute),
+      replaceUrl: true
+    });
+  });
+
+  it('should warn when quick tracking without number', () => {
+    component.trackingNumber = '';
+    component.quickTrack();
+    expect(notif.show).toHaveBeenCalledWith('Please enter a tracking number', 'warning');
+  });
+
+  it('should navigate on quick tracking', fakeAsync(() => {
+    const navigateSpy = spyOn(router, 'navigate');
+    component.trackingNumber = 'GBX123';
+    component.quickTrack();
+
+    expect(notif.show).toHaveBeenCalledWith('Tracking package GBX123...', 'info');
+    tick(1500);
+    expect(navigateSpy).toHaveBeenCalledWith(['/tracking'], {
+      queryParams: { number: 'GBX123', type: 'quick' }
+    });
+  }));
+});

--- a/src/app/pages/help/tracking-advice/tracking-advice.component.spec.ts
+++ b/src/app/pages/help/tracking-advice/tracking-advice.component.spec.ts
@@ -1,0 +1,33 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TrackingAdviceComponent } from './tracking-advice.component';
+import { NotificationService } from '../../../shared/services/notification.service';
+
+class MockNotificationService { show = jasmine.createSpy('show'); }
+
+describe('TrackingAdviceComponent', () => {
+  let component: TrackingAdviceComponent;
+  let fixture: ComponentFixture<TrackingAdviceComponent>;
+  let notif: MockNotificationService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TrackingAdviceComponent],
+      providers: [{ provide: NotificationService, useClass: MockNotificationService }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TrackingAdviceComponent);
+    component = fixture.componentInstance;
+    notif = TestBed.inject(NotificationService) as any;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should notify when opening guides', () => {
+    component.openTrackingGuide();
+    component.openStatusGuide();
+    expect(notif.show).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/pages/help/tracking-tools/tracking-tools.component.spec.ts
+++ b/src/app/pages/help/tracking-tools/tracking-tools.component.spec.ts
@@ -1,0 +1,33 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TrackingToolsComponent } from './tracking-tools.component';
+import { NotificationService } from '../../../shared/services/notification.service';
+
+class MockNotificationService { show = jasmine.createSpy('show'); }
+
+describe('TrackingToolsComponent', () => {
+  let component: TrackingToolsComponent;
+  let fixture: ComponentFixture<TrackingToolsComponent>;
+  let notif: MockNotificationService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TrackingToolsComponent],
+      providers: [{ provide: NotificationService, useClass: MockNotificationService }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TrackingToolsComponent);
+    component = fixture.componentInstance;
+    notif = TestBed.inject(NotificationService) as any;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should notify when opening tools', () => {
+    component.openBulkTracking();
+    component.openAPI();
+    expect(notif.show).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/pages/home/components/cta/cta-section.component.scss
+++ b/src/app/pages/home/components/cta/cta-section.component.scss
@@ -1,3 +1,6 @@
+@use "sass:color";
+@use "../../../../../styles/variables" as *;
+@use "../../../../../styles/mixins" as *;
 // CTA Section
 .cta {
   @include section-padding;

--- a/src/app/pages/home/components/faq/faq-section.component.scss
+++ b/src/app/pages/home/components/faq/faq-section.component.scss
@@ -1,3 +1,6 @@
+@use "sass:color";
+@use "../../../../../styles/variables" as *;
+@use "../../../../../styles/mixins" as *;
 // FAQ Section
 .faq {
   @include section-padding;

--- a/src/app/pages/home/components/hero/hero-section.component.scss
+++ b/src/app/pages/home/components/hero/hero-section.component.scss
@@ -1,3 +1,6 @@
+@use "sass:color";
+@use "../../../../../styles/variables" as *;
+@use "../../../../../styles/mixins" as *;
 // Hero Section
 .hero {
   background: url('/assets/images/hero/hero-bg.jpg') center/cover no-repeat;

--- a/src/app/pages/home/components/locations/locations-section.component.scss
+++ b/src/app/pages/home/components/locations/locations-section.component.scss
@@ -1,3 +1,6 @@
+@use "sass:color";
+@use "../../../../../styles/variables" as *;
+@use "../../../../../styles/mixins" as *;
 // Locations Section
 .locations-section {
   @include section-padding;

--- a/src/app/pages/home/components/news/news-section.component.scss
+++ b/src/app/pages/home/components/news/news-section.component.scss
@@ -1,3 +1,6 @@
+@use "sass:color";
+@use "../../../../../styles/variables" as *;
+@use "../../../../../styles/mixins" as *;
 // News Section
 .news {
   @include section-padding;

--- a/src/app/pages/home/components/services/services-section.component.scss
+++ b/src/app/pages/home/components/services/services-section.component.scss
@@ -1,3 +1,6 @@
+@use "sass:color";
+@use "../../../../../styles/variables" as *;
+@use "../../../../../styles/mixins" as *;
 // Services Section
 .services {
   @include section-padding;

--- a/src/app/shared/services/notification.service.ts
+++ b/src/app/shared/services/notification.service.ts
@@ -99,11 +99,24 @@ export class NotificationService {
   }
 
   /**
-   * Show a custom notification
-   * @param notification Notification object
+   * Show a custom notification or quick message
    */
-  show(notification: Notification): void {
-    this.notificationSubject.next(notification);
+  show(notification: Notification): void;
+  show(message: string, type: Notification['type']): void;
+  show(arg1: Notification | string, arg2?: Notification['type']): void {
+    if (typeof arg1 === 'string') {
+      const notification: Notification = {
+        id: this.getNextId(),
+        type: arg2 ?? 'info',
+        title: arg1,
+        message: '',
+        duration: 5000,
+        visible: false
+      };
+      this.notificationSubject.next(notification);
+    } else {
+      this.notificationSubject.next(arg1);
+    }
   }
 
   /**

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -1,0 +1,26 @@
+@mixin flex-center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@mixin section-padding {
+  padding: 80px 0;
+}
+
+@mixin container {
+  width: 100%;
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0;
+}
+
+@mixin card-shadow {
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+
+  &:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+  }
+}


### PR DESCRIPTION
## Summary
- add NotificationService show overload
- add SCSS mixins and import paths
- test HelpComponent interactions and navigation
- test FAQs, tracking tools/advice and contact form components

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: Cannot start ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_684cf3a94a2c832e91adc48c2ed6eedc