### PR TITLE
Add reusable loader component

### DIFF
--- a/src/app/features/auth/components/email-verification/email-verification.component.html
+++ b/src/app/features/auth/components/email-verification/email-verification.component.html
@@ -17,7 +17,7 @@
       <p>Saisissez le code à 6 chiffres envoyé à <strong>{{ userEmail }}</strong></p>
     </div>
 
-    <div class="auth-form">
+    <div class="auth-form" [class.loading]="isLoading">
       <form [formGroup]="verificationForm" (ngSubmit)="onSubmit()">
         <!-- Verification Code -->
         <div class="form-field">
@@ -67,8 +67,9 @@
             <span *ngIf="canResend">Renvoyer le code</span>
             <span *ngIf="!canResend">Renvoyer dans {{ countdown }}s</span>
           </button>
-        </div>
+      </div>
       </form>
+      <app-loader *ngIf="isLoading"></app-loader>
     </div>
 
     <!-- Footer -->

--- a/src/app/features/auth/components/email-verification/email-verification.component.scss
+++ b/src/app/features/auth/components/email-verification/email-verification.component.scss
@@ -74,6 +74,19 @@
   padding: 2rem;
 }
 
+.auth-form.loading {
+  position: relative;
+  pointer-events: none;
+  opacity: 0.6;
+
+  app-loader {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+}
+
 .form-field {
   margin-bottom: 1.5rem;
 }

--- a/src/app/features/auth/components/email-verification/email-verification.component.ts
+++ b/src/app/features/auth/components/email-verification/email-verification.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Router, ActivatedRoute, RouterModule } from '@angular/router';
+import { LoaderComponent } from '../../../shared/components/loader/loader.component';
 
 @Component({
   selector: 'app-email-verification',
@@ -9,7 +10,8 @@ import { Router, ActivatedRoute, RouterModule } from '@angular/router';
   imports: [
     CommonModule,
     ReactiveFormsModule,
-    RouterModule
+    RouterModule,
+    LoaderComponent
   ],
   templateUrl: './email-verification.component.html',
   styleUrls: ['./email-verification.component.scss']

--- a/src/app/features/auth/components/forgot-password/forgot-password.component.html
+++ b/src/app/features/auth/components/forgot-password/forgot-password.component.html
@@ -40,7 +40,7 @@
     </div>
 
     <!-- Initial State Form -->
-    <div class="auth-form" *ngIf="!emailSent">
+    <div class="auth-form" *ngIf="!emailSent" [class.loading]="isLoading">
       <form [formGroup]="forgotPasswordForm" (ngSubmit)="onSubmit()">
         <!-- Email Field -->
         <div class="form-field">
@@ -79,6 +79,7 @@
           <span *ngIf="isLoading">Envoi en cours...</span>
         </button>
       </form>
+      <app-loader *ngIf="isLoading"></app-loader>
     </div>
 
     <!-- Success State Content -->

--- a/src/app/features/auth/components/forgot-password/forgot-password.component.scss
+++ b/src/app/features/auth/components/forgot-password/forgot-password.component.scss
@@ -256,6 +256,19 @@
   }
 }
 
+.auth-form.loading {
+  position: relative;
+  pointer-events: none;
+  opacity: 0.6;
+
+  app-loader {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+}
+
 @media (max-width: 600px) {
   .auth-container {
     padding: 0.5rem;

--- a/src/app/features/auth/components/forgot-password/forgot-password.component.ts
+++ b/src/app/features/auth/components/forgot-password/forgot-password.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
+import { LoaderComponent } from '../../../shared/components/loader/loader.component';
 
 // TODO: Backend - Create Password Reset Interfaces
 /*
@@ -75,7 +76,8 @@ POST /api/auth/validate-reset-token
   imports: [
     CommonModule,
     ReactiveFormsModule,
-    RouterModule
+    RouterModule,
+    LoaderComponent
   ],
   templateUrl: './forgot-password.component.html',
   styleUrls: ['./forgot-password.component.scss']

--- a/src/app/features/auth/components/login/login.component.html
+++ b/src/app/features/auth/components/login/login.component.html
@@ -19,7 +19,7 @@
     </div>
 
     <!-- Form Section -->
-    <div class="auth-form">
+    <div class="auth-form" [class.loading]="isLoading">
       <form [formGroup]="loginForm" (ngSubmit)="onSubmit()">
         <!-- Email Field -->
         <div class="form-field">
@@ -107,6 +107,7 @@
           Continuer avec Google
         </button>
       </form>
+      <app-loader *ngIf="isLoading"></app-loader>
     </div>
 
     <!-- Footer -->

--- a/src/app/features/auth/components/login/login.component.scss
+++ b/src/app/features/auth/components/login/login.component.scss
@@ -260,6 +260,19 @@
   color: #999 !important;
 }
 
+.auth-form.loading {
+  position: relative;
+  pointer-events: none;
+  opacity: 0.6;
+
+  app-loader {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+}
+
 @media (max-width: 480px) {
   .auth-container {
     padding: 0.5rem;

--- a/src/app/features/auth/components/login/login.component.ts
+++ b/src/app/features/auth/components/login/login.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
+import { LoaderComponent } from '../../../shared/components/loader/loader.component';
 
 // TODO: Backend - Create Login Interface
 /*
@@ -83,7 +84,8 @@ POST /api/auth/google/login
   imports: [
     CommonModule,
     ReactiveFormsModule,
-    RouterModule
+    RouterModule,
+    LoaderComponent
   ],
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.scss']

--- a/src/app/features/auth/components/register/register.component.html
+++ b/src/app/features/auth/components/register/register.component.html
@@ -20,7 +20,7 @@
     </div>
 
     <!-- Form Section -->
-    <div class="auth-form">
+    <div class="auth-form" [class.loading]="isLoading">
       <form [formGroup]="registerForm" (ngSubmit)="onSubmit()">
         
         <!-- Name Fields Row -->
@@ -197,6 +197,7 @@
           S'inscrire avec Google
         </button>
       </form>
+      <app-loader *ngIf="isLoading"></app-loader>
     </div>
 
     <!-- Footer -->

--- a/src/app/features/auth/components/register/register.component.scss
+++ b/src/app/features/auth/components/register/register.component.scss
@@ -228,6 +228,19 @@
   }
 }
 
+.auth-form.loading {
+  position: relative;
+  pointer-events: none;
+  opacity: 0.6;
+
+  app-loader {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+}
+
 .divider {
   display: flex;
   align-items: center;

--- a/src/app/features/auth/components/register/register.component.ts
+++ b/src/app/features/auth/components/register/register.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule, AbstractControl } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
+import { LoaderComponent } from '../../../shared/components/loader/loader.component';
 
 // TODO: Backend - Create User Interface
 /*
@@ -79,7 +80,8 @@ function passwordMatchValidator(control: AbstractControl): {[key: string]: any} 
   imports: [
     CommonModule,
     ReactiveFormsModule,
-    RouterModule
+    RouterModule,
+    LoaderComponent
   ],
   templateUrl: './register.component.html',
   styleUrls: ['./register.component.scss']

--- a/src/app/shared/components/loader/loader.component.html
+++ b/src/app/shared/components/loader/loader.component.html
@@ -1,0 +1,1 @@
+<div class="loader-spinner"></div>

--- a/src/app/shared/components/loader/loader.component.scss
+++ b/src/app/shared/components/loader/loader.component.scss
@@ -1,0 +1,12 @@
+.loader-spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid #e0e0e0;
+  border-top-color: #4527A0;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/src/app/shared/components/loader/loader.component.ts
+++ b/src/app/shared/components/loader/loader.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-loader',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './loader.component.html',
+  styleUrls: ['./loader.component.scss']
+})
+export class LoaderComponent {}


### PR DESCRIPTION
## Summary
- create standalone `LoaderComponent`
- show loader in auth forms when `isLoading` is true
- disable form interactions while loading

## Testing
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*
- `npx tsc -p tsconfig.app.json` *(fails: missing Angular dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684cf3caf00c832eacc93133329a12d4